### PR TITLE
Revert "MIDI: Remove Rescan spam"

### DIFF
--- a/Apollo/Core/MIDI.cs
+++ b/Apollo/Core/MIDI.cs
@@ -171,7 +171,7 @@ namespace Apollo.Core {
                     if (device.GetType() == typeof(Launchpad) && device.Available)
                         Disconnect(device);
 
-                Program.Log("");
+                Program.Log($"Rescan");
 
                 if (updated) Update();
             }

--- a/Apollo/Core/Program.cs
+++ b/Apollo/Core/Program.cs
@@ -46,10 +46,7 @@ namespace Apollo.Core {
         public static bool LaunchUpdater = false;
         
         public static Stopwatch TimeSpent = new Stopwatch();
-        public static void Log(string text) {
-            if (text == "") Console.Write(text);
-            else Console.WriteLine($"[{TimeSpent.Elapsed.ToString()}] {text}");
-        }
+        public static void Log(string text) => Console.WriteLine($"[{TimeSpent.Elapsed.ToString()}] {text}");
 
         public delegate void ProjectLoadedEventHandler();
         public static event ProjectLoadedEventHandler ProjectLoaded;


### PR DESCRIPTION
This reverts commit 680616692a56a8fa94c8771e38cf653b83c3c760.

From my testing, Rescan spam is not necessary to avoid segfault, only an empty string is good enough. However, from Sergio Valentino's tests, it seems that's not enough and Apollo still segfaults. This reverts back to the safe old behavior where we spam Rescan to the Console.

This should help anyone with macOS who's received Segmentation fault errors, although I can't reproduce them with current releases.