### PR TITLE
FadeViewer: Color of new thumbs matches visible gradient

### DIFF
--- a/Apollo/DeviceViewers/FadeViewer.cs
+++ b/Apollo/DeviceViewers/FadeViewer.cs
@@ -170,13 +170,11 @@ namespace Apollo.DeviceViewers {
                 double time = pos * _fade.Time;
                 
                 int fadeIndex = 0;
-                for(int i = 0; i < fullFade.Count; i++){
-                    if(Math.Abs(fullFade[i].Time - time) < Math.Abs(fullFade[fadeIndex].Time - time)){
+                for (int i = 0; i < fullFade.Count; i++)
+                    if (Math.Abs(fullFade[i].Time - time) < Math.Abs(fullFade[fadeIndex].Time - time))
                         fadeIndex = i;
-                    }
-                }
                 
-                Color thumbColor = fullFade[fadeIndex].Color;
+                Color thumbColor = fullFade[fadeIndex].Color.Clone();
                 
                 List<int> path = Track.GetPath(_fade);
 
@@ -186,7 +184,7 @@ namespace Apollo.DeviceViewers {
                     ((Fade)Track.TraversePath(path)).Insert(index, thumbColor, pos, FadeType.Linear);
                 });
 
-                _fade.Insert(index, thumbColor, pos, FadeType.Linear);
+                _fade.Insert(index, thumbColor.Clone(), pos, FadeType.Linear);
             }
         }
 
@@ -493,6 +491,5 @@ namespace Apollo.DeviceViewers {
         }
 
         void Input_MouseUp(object sender, PointerReleasedEventArgs e) => e.Handled = true;
-        
     }
 }

--- a/Apollo/DeviceViewers/FadeViewer.cs
+++ b/Apollo/DeviceViewers/FadeViewer.cs
@@ -53,6 +53,7 @@ namespace Apollo.DeviceViewers {
         LinearGradientBrush Gradient;
 
         List<FadeThumb> thumbs = new List<FadeThumb>();
+        List<Fade.FadeInfo> fullFade;
 
         public void Contents_Insert(int index, Color color) {
             FadeThumb thumb = new FadeThumb() {
@@ -165,16 +166,27 @@ namespace Apollo.DeviceViewers {
                     if (x < Canvas.GetLeft(thumbs[index])) break;
                 
                 double pos = x / 200;
-
+                
+                double time = pos * _fade.Time;
+                
+                int fadeIndex = 0;
+                for(int i = 0; i < fullFade.Count; i++){
+                    if(Math.Abs(fullFade[i].Time - time) < Math.Abs(fullFade[fadeIndex].Time - time)){
+                        fadeIndex = i;
+                    }
+                }
+                
+                Color thumbColor = fullFade[fadeIndex].Color;
+                
                 List<int> path = Track.GetPath(_fade);
 
                 Program.Project.Undo.Add($"Fade Color {index + 1} Inserted", () => {
                     ((Fade)Track.TraversePath(path)).Remove(index);
                 }, () => {
-                    ((Fade)Track.TraversePath(path)).Insert(index, new Color(), pos, FadeType.Linear);
+                    ((Fade)Track.TraversePath(path)).Insert(index, thumbColor, pos, FadeType.Linear);
                 });
 
-                _fade.Insert(index, new Color(), pos, FadeType.Linear);
+                _fade.Insert(index, thumbColor, pos, FadeType.Linear);
             }
         }
 
@@ -278,6 +290,8 @@ namespace Apollo.DeviceViewers {
 
         void Gradient_Generate(List<Fade.FadeInfo> points) {
             if (Program.Project.IsDisposing) return;
+            
+            fullFade = points;
             
             Dispatcher.UIThread.InvokeAsync(() => {
                 Gradient.GradientStops.Clear();
@@ -479,5 +493,6 @@ namespace Apollo.DeviceViewers {
         }
 
         void Input_MouseUp(object sender, PointerReleasedEventArgs e) => e.Handled = true;
+        
     }
 }


### PR DESCRIPTION
Uses a linear search to find the nearest FadeInfo to the thumb's time, and sets the thumb's color accordingly. Could be optimised to use a binary search, but fullFade will usually only have 65-70 elements so it may not be worth it.