### PR TITLE
ColorPicker: Right click + drag locks to one axis

### DIFF
--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Avalonia;
@@ -33,6 +33,11 @@ namespace Apollo.Components {
             MainColor = ((LinearGradientBrush)this.Get<Grid>("MainColor").Background).GradientStops[1];
             
             Hex = this.Get<TextBox>("Hex");
+            
+            TopBar = this.Get<Rectangle>("TopBar");
+            BottomBar = this.Get<Rectangle>("BottomBar");
+            LeftBar = this.Get<Rectangle>("LeftBar");
+            RightBar = this.Get<Rectangle>("RightBar");
         }
 
         enum MouseLock{
@@ -69,6 +74,7 @@ namespace Apollo.Components {
         Thumb MainThumb, HueThumb;
         GradientStop MainColor;
         TextBox Hex;
+        Rectangle TopBar, BottomBar, LeftBar, RightBar;
 
         bool main_mouseHeld, hue_mouseHeld, hexValidation;
         MouseLock mouseLock = MouseLock.None;
@@ -175,6 +181,7 @@ namespace Apollo.Components {
             PointerUpdateKind MouseButton = e.GetCurrentPoint(this).Properties.PointerUpdateKind;
             
             mouseLock = MouseLock.None;
+            HideAxes();
 
             if (MouseButton == PointerUpdateKind.LeftButtonReleased && oldColor != Color)
                 ColorChanged?.Invoke(Color, oldColor);
@@ -189,37 +196,45 @@ namespace Apollo.Components {
                 else
                     mouseLock = MouseLock.Vertical;
             } else if(mouseLock == MouseLock.None){
-                    x = Canvas.GetLeft(MainThumb) + e.Vector.X;
-                    x = (x < 0)? 0 : x;
-                    x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;    
-                        
-                    y = Canvas.GetTop(MainThumb) + e.Vector.Y;
-                    y = (y < 0)? 0 : y;
-                    y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
-                    
+                x = Canvas.GetLeft(MainThumb) + e.Vector.X;
+                x = (x < 0)? 0 : x;
+                x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;
+
+                y = Canvas.GetTop(MainThumb) + e.Vector.Y;
+                y = (y < 0)? 0 : y;
+                y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
+
                 Canvas.SetLeft(MainThumb, x);
-                    Canvas.SetTop(MainThumb, y);
+                Canvas.SetTop(MainThumb, y);
                 
                 UpdateColor();
 
                 return;
             }
-
+            
             if(mouseLock == MouseLock.Horizontal){
                 x = Canvas.GetLeft(MainThumb) + e.Vector.X;
                 x = (x < 0)? 0 : x;
                 x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;        
                 Canvas.SetLeft(MainThumb, x);
+                
+                UpdateThumbAxes();
+                
+                LeftBar.IsVisible = true;
+                RightBar.IsVisible = true;
             } else if(mouseLock == MouseLock.Vertical){
                 y = Canvas.GetTop(MainThumb) + e.Vector.Y;
                 y = (y < 0)? 0 : y;
                 y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
                 
                 Canvas.SetTop(MainThumb, y);
+                UpdateThumbAxes();
+                
+                TopBar.IsVisible = true;
+                BottomBar.IsVisible = true;
             }
             
             UpdateColor();
-            
         }
 
         void MainCanvas_MouseDown(object sender, PointerPressedEventArgs e) {
@@ -381,6 +396,31 @@ namespace Apollo.Components {
                 ColorChanged?.Invoke(Color, oldColor);
 
             Hex_Dirty = false;
+        }
+    
+        void UpdateThumbAxes(){
+            double ThumbLeft = MainThumb.GetValue(Canvas.LeftProperty);
+            double ThumbTop = MainThumb.GetValue(Canvas.TopProperty);
+            
+            TopBar.SetValue(Canvas.LeftProperty, ThumbLeft - 0.5);
+            TopBar.SetValue(Canvas.TopProperty, ThumbTop - 504);
+            
+            BottomBar.SetValue(Canvas.LeftProperty, ThumbLeft - 0.5);
+            BottomBar.SetValue(Canvas.TopProperty, ThumbTop + 4);
+            
+            LeftBar.SetValue(Canvas.LeftProperty, ThumbLeft - 504);
+            LeftBar.SetValue(Canvas.TopProperty, ThumbTop - 0.5);
+            
+            RightBar.SetValue(Canvas.LeftProperty, ThumbLeft + 4);
+            RightBar.SetValue(Canvas.TopProperty, ThumbTop - 0.5);
+        }
+   
+        void HideAxes(){
+            TopBar.IsVisible = false;
+            BottomBar.IsVisible = false;
+            LeftBar.IsVisible = false;
+            RightBar.IsVisible = false;
+
         }
     }
 }

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -211,7 +211,7 @@ namespace Apollo.Components {
                 y = (y < 0)? 0 : y;
                 y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
             }
-
+            
             Canvas.SetLeft(MainThumb, x);
             Canvas.SetTop(MainThumb, y);
             
@@ -384,17 +384,24 @@ namespace Apollo.Components {
             double ThumbLeft = MainThumb.GetValue(Canvas.LeftProperty);
             double ThumbTop = MainThumb.GetValue(Canvas.TopProperty);
             
+            double width = MainCanvas.Bounds.Width;
+            double height = MainCanvas.Bounds.Height;
+            
             TopBar.SetValue(Canvas.LeftProperty, ThumbLeft - 0.5);
-            TopBar.SetValue(Canvas.TopProperty, ThumbTop - 504);
+            TopBar.SetValue(Canvas.TopProperty, ThumbTop - 4 - height);
+            TopBar.SetValue(HeightProperty, height);
             
             BottomBar.SetValue(Canvas.LeftProperty, ThumbLeft - 0.5);
             BottomBar.SetValue(Canvas.TopProperty, ThumbTop + 4);
+            BottomBar.SetValue(HeightProperty, height);
             
-            LeftBar.SetValue(Canvas.LeftProperty, ThumbLeft - 504);
+            LeftBar.SetValue(Canvas.LeftProperty, ThumbLeft - 4 - width);
             LeftBar.SetValue(Canvas.TopProperty, ThumbTop - 0.5);
+            LeftBar.SetValue(WidthProperty, width);
             
             RightBar.SetValue(Canvas.LeftProperty, ThumbLeft + 4);
             RightBar.SetValue(Canvas.TopProperty, ThumbTop - 0.5);
+            RightBar.SetValue(WidthProperty, width);
         }
     }
 }

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Avalonia;
@@ -183,55 +183,43 @@ namespace Apollo.Components {
         void MainThumb_Move(object sender, VectorEventArgs e) {
             double x, y;
             
-            switch (mouseLock){
-            case MouseLock.Ready:
-                if(Math.Abs(e.Vector.X) > Math.Abs(e.Vector.Y)){
+            if (mouseLock == MouseLock.Ready){
+                if(Math.Abs(e.Vector.X) > Math.Abs(e.Vector.Y))
                     mouseLock = MouseLock.Horizontal;
-                    
+                else
+                    mouseLock = MouseLock.Vertical;
+            } else if(mouseLock == MouseLock.None){
                     x = Canvas.GetLeft(MainThumb) + e.Vector.X;
                     x = (x < 0)? 0 : x;
                     x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;    
                         
-                    Canvas.SetLeft(MainThumb, x);
-                } else {
-                    mouseLock = MouseLock.Vertical;
-                    
                     y = Canvas.GetTop(MainThumb) + e.Vector.Y;
                     y = (y < 0)? 0 : y;
                     y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
                     
-                    Canvas.SetTop(MainThumb, y);
-                }
-                
-                break;
-            case MouseLock.None:
-                x = Canvas.GetLeft(MainThumb) + e.Vector.X;
-                x = (x < 0)? 0 : x;
-                x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;
-
-                y = Canvas.GetTop(MainThumb) + e.Vector.Y;
-                y = (y < 0)? 0 : y;
-                y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
-
                 Canvas.SetLeft(MainThumb, x);
-                Canvas.SetTop(MainThumb, y);
-                break;
-            case MouseLock.Horizontal:
+                    Canvas.SetTop(MainThumb, y);
+                
+                UpdateColor();
+
+                return;
+            }
+
+            if(mouseLock == MouseLock.Horizontal){
                 x = Canvas.GetLeft(MainThumb) + e.Vector.X;
                 x = (x < 0)? 0 : x;
                 x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;        
                 Canvas.SetLeft(MainThumb, x);
-                break;
-            case MouseLock.Vertical:
+            } else if(mouseLock == MouseLock.Vertical){
                 y = Canvas.GetTop(MainThumb) + e.Vector.Y;
                 y = (y < 0)? 0 : y;
                 y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
                 
                 Canvas.SetTop(MainThumb, y);
-                break;
             }
             
             UpdateColor();
+            
         }
 
         void MainCanvas_MouseDown(object sender, PointerPressedEventArgs e) {

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -40,7 +40,7 @@ namespace Apollo.Components {
             RightBar = this.Get<Rectangle>("RightBar");
         }
 
-        enum MouseLock{
+        enum MouseLock {
             Horizontal,
             Vertical,
             None,
@@ -173,7 +173,7 @@ namespace Apollo.Components {
 
             if (MouseButton == PointerUpdateKind.LeftButtonPressed)
                 oldColor = Color.Clone();
-            else if(MouseButton == PointerUpdateKind.RightButtonPressed)
+            else if (MouseButton == PointerUpdateKind.RightButtonPressed)
                 mouseLock = MouseLock.Ready;
         }
 
@@ -181,60 +181,42 @@ namespace Apollo.Components {
             PointerUpdateKind MouseButton = e.GetCurrentPoint(this).Properties.PointerUpdateKind;
             
             mouseLock = MouseLock.None;
-            HideAxes();
+            TopBar.IsVisible = BottomBar.IsVisible = LeftBar.IsVisible = RightBar.IsVisible = false;
 
             if (MouseButton == PointerUpdateKind.LeftButtonReleased && oldColor != Color)
                 ColorChanged?.Invoke(Color, oldColor);
         }
 
         void MainThumb_Move(object sender, VectorEventArgs e) {
-            double x, y;
+            double x = Canvas.GetLeft(MainThumb);
+            double y = Canvas.GetTop(MainThumb);
             
-            if (mouseLock == MouseLock.Ready){
-                if(Math.Abs(e.Vector.X) > Math.Abs(e.Vector.Y))
+            if (mouseLock == MouseLock.Ready)
+                if (Math.Abs(e.Vector.X) > Math.Abs(e.Vector.Y)) {
                     mouseLock = MouseLock.Horizontal;
-                else
+                    LeftBar.IsVisible = RightBar.IsVisible = true;
+                } else {
                     mouseLock = MouseLock.Vertical;
-            } else if(mouseLock == MouseLock.None){
-                x = Canvas.GetLeft(MainThumb) + e.Vector.X;
+                    TopBar.IsVisible = BottomBar.IsVisible = true;
+                }
+
+            if (mouseLock == MouseLock.None || mouseLock == MouseLock.Horizontal) {
+                x += e.Vector.X;
                 x = (x < 0)? 0 : x;
                 x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;
+            }
 
-                y = Canvas.GetTop(MainThumb) + e.Vector.Y;
+            if (mouseLock == MouseLock.None || mouseLock == MouseLock.Vertical) {
+                y += e.Vector.Y;
                 y = (y < 0)? 0 : y;
                 y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
-
-                Canvas.SetLeft(MainThumb, x);
-                Canvas.SetTop(MainThumb, y);
-                
-                UpdateColor();
-
-                return;
             }
-            
-            if(mouseLock == MouseLock.Horizontal){
-                x = Canvas.GetLeft(MainThumb) + e.Vector.X;
-                x = (x < 0)? 0 : x;
-                x = (x > MainCanvas.Bounds.Width)? MainCanvas.Bounds.Width : x;        
-                Canvas.SetLeft(MainThumb, x);
-                
-                UpdateThumbAxes();
-                
-                LeftBar.IsVisible = true;
-                RightBar.IsVisible = true;
-            } else if(mouseLock == MouseLock.Vertical){
-                y = Canvas.GetTop(MainThumb) + e.Vector.Y;
-                y = (y < 0)? 0 : y;
-                y = (y > MainCanvas.Bounds.Height)? MainCanvas.Bounds.Height : y;
-                
-                Canvas.SetTop(MainThumb, y);
-                UpdateThumbAxes();
-                
-                TopBar.IsVisible = true;
-                BottomBar.IsVisible = true;
-            }
+
+            Canvas.SetLeft(MainThumb, x);
+            Canvas.SetTop(MainThumb, y);
             
             UpdateColor();
+            UpdateThumbAxes();
         }
 
         void MainCanvas_MouseDown(object sender, PointerPressedEventArgs e) {
@@ -398,7 +380,7 @@ namespace Apollo.Components {
             Hex_Dirty = false;
         }
     
-        void UpdateThumbAxes(){
+        void UpdateThumbAxes() {
             double ThumbLeft = MainThumb.GetValue(Canvas.LeftProperty);
             double ThumbTop = MainThumb.GetValue(Canvas.TopProperty);
             
@@ -413,14 +395,6 @@ namespace Apollo.Components {
             
             RightBar.SetValue(Canvas.LeftProperty, ThumbLeft + 4);
             RightBar.SetValue(Canvas.TopProperty, ThumbTop - 0.5);
-        }
-   
-        void HideAxes(){
-            TopBar.IsVisible = false;
-            BottomBar.IsVisible = false;
-            LeftBar.IsVisible = false;
-            RightBar.IsVisible = false;
-
         }
     }
 }

--- a/Apollo/Components/ColorPicker.xaml
+++ b/Apollo/Components/ColorPicker.xaml
@@ -26,7 +26,7 @@
 
             <Canvas Background="Transparent" ClipToBounds="true" x:Name="MainCanvas"
                     PointerPressed="MainCanvas_MouseDown" PointerReleased="MainCanvas_MouseUp" PointerMoved="MainCanvas_MouseMove">
-              <Thumb Canvas.Left="0" Canvas.Top="0" Margin="-5 -5 0 0" Width="10" Height="10" Cursor="Hand" x:Name="MainThumb" Name="MainThumb" DragDelta="MainThumb_Move">
+              <Thumb Canvas.Left="0" Canvas.Top="0" Margin="-5 -5 0 0" Width="10" Height="10" Cursor="Hand" x:Name="MainThumb" DragDelta="MainThumb_Move">
                 <Thumb.Template>
                   <ControlTemplate>
                     <Canvas Background="Transparent">

--- a/Apollo/Components/ColorPicker.xaml
+++ b/Apollo/Components/ColorPicker.xaml
@@ -37,10 +37,10 @@
                 </Thumb.Template>
               </Thumb>
               
-              <Rectangle IsVisible="false" x:Name="TopBar" Fill="#FFFFFF" Width="1" Height="500"/>
-              <Rectangle IsVisible="false" x:Name="BottomBar" Fill="#FFFFFF" Width="1" Height="500"/>
-              <Rectangle IsVisible="false" x:Name="LeftBar" Fill="#FFFFFF" Width="500" Height="1"/>
-              <Rectangle IsVisible="false" x:Name="RightBar" Fill="#FFFFFF" Width="500" Height="1"/>
+              <Rectangle IsVisible="false" x:Name="TopBar" Fill="#FFFFFF" Width="1" />
+              <Rectangle IsVisible="false" x:Name="BottomBar" Fill="#FFFFFF" Width="1"/>
+              <Rectangle IsVisible="false" x:Name="LeftBar" Fill="#FFFFFF" Height="1"/>
+              <Rectangle IsVisible="false" x:Name="RightBar" Fill="#FFFFFF" Height="1"/>
             </Canvas>
           </Grid>
         </Grid>

--- a/Apollo/Components/ColorPicker.xaml
+++ b/Apollo/Components/ColorPicker.xaml
@@ -26,7 +26,7 @@
 
             <Canvas Background="Transparent" ClipToBounds="true" x:Name="MainCanvas"
                     PointerPressed="MainCanvas_MouseDown" PointerReleased="MainCanvas_MouseUp" PointerMoved="MainCanvas_MouseMove">
-              <Thumb Canvas.Left="0" Canvas.Top="0" Margin="-5 -5 0 0" Width="10" Height="10" Cursor="Hand" x:Name="MainThumb" DragDelta="MainThumb_Move">
+              <Thumb Canvas.Left="0" Canvas.Top="0" Margin="-5 -5 0 0" Width="10" Height="10" Cursor="Hand" x:Name="MainThumb" Name="MainThumb" DragDelta="MainThumb_Move">
                 <Thumb.Template>
                   <ControlTemplate>
                     <Canvas Background="Transparent">
@@ -36,6 +36,11 @@
                   </ControlTemplate>
                 </Thumb.Template>
               </Thumb>
+              
+              <Rectangle IsVisible="false" x:Name="TopBar" Fill="#FFFFFF" Width="1" Height="500"/>
+              <Rectangle IsVisible="false" x:Name="BottomBar" Fill="#FFFFFF" Width="1" Height="500"/>
+              <Rectangle IsVisible="false" x:Name="LeftBar" Fill="#FFFFFF" Width="500" Height="1"/>
+              <Rectangle IsVisible="false" x:Name="RightBar" Fill="#FFFFFF" Width="500" Height="1"/>
             </Canvas>
           </Grid>
         </Grid>


### PR DESCRIPTION
Closes #310, allowing for the ColorPicker main thumb to be dragged on either the X or Y axis independently. While doing so, a line representing the axis that is being dragged along is shown. This could be changed to show both the X and Y axes, but I don't believe this would make sense as the thumb would be locked to one, with the other serving no purpose.