### PR TITLE
ColorPicker: Add RGB color option

### DIFF
--- a/Apollo/Binary/Common.cs
+++ b/Apollo/Binary/Common.cs
@@ -8,7 +8,7 @@ using Apollo.Structures;
 
 namespace Apollo.Binary {
     public static class Common {
-        public const int version = 27;
+        public const int version = 28;
 
         public static readonly Type[] id = new Type[] {
             typeof(Preferences),

--- a/Apollo/Binary/Decoder.cs
+++ b/Apollo/Binary/Decoder.cs
@@ -148,6 +148,9 @@ namespace Apollo.Binary {
 
                 if (version >= 17)
                     Preferences.BaseTime = reader.ReadInt64();
+                    
+                if (version >= 27)
+                    Preferences.ColorMode = (ColorModeType)reader.ReadInt32();
                 
                 return null;
 

--- a/Apollo/Binary/Decoder.cs
+++ b/Apollo/Binary/Decoder.cs
@@ -63,6 +63,10 @@ namespace Apollo.Binary {
                 } else if (version >= 23) {
                     Preferences.ChainSignalIndicators = Preferences.DeviceSignalIndicators = reader.ReadBoolean();
                 }
+                
+                if (version >= 28) {
+                    Preferences.ColorDisplayFormat = (ColorDisplayType)reader.ReadInt32();
+                }
 
                 if (version >= 9) {
                     Preferences.LaunchpadStyle = (LaunchpadStyles)reader.ReadInt32();
@@ -148,9 +152,6 @@ namespace Apollo.Binary {
 
                 if (version >= 17)
                     Preferences.BaseTime = reader.ReadInt64();
-                    
-                if (version >= 27)
-                    Preferences.ColorMode = (ColorModeType)reader.ReadInt32();
                 
                 return null;
 

--- a/Apollo/Binary/Encoder.cs
+++ b/Apollo/Binary/Encoder.cs
@@ -97,6 +97,8 @@ namespace Apollo.Binary {
                 writer.Write(Preferences.CheckForUpdates);
 
                 writer.Write(Preferences.Time);
+                
+                writer.Write((int)Preferences.ColorMode);
             }
 
             return output;

--- a/Apollo/Binary/Encoder.cs
+++ b/Apollo/Binary/Encoder.cs
@@ -41,6 +41,8 @@ namespace Apollo.Binary {
 
                 writer.Write(Preferences.ChainSignalIndicators);
                 writer.Write(Preferences.DeviceSignalIndicators);
+                
+                writer.Write((int)Preferences.ColorDisplayFormat);
 
                 writer.Write((int)Preferences.LaunchpadStyle);
                 writer.Write(Convert.ToInt32(Preferences.LaunchpadGridRotation));
@@ -97,8 +99,6 @@ namespace Apollo.Binary {
                 writer.Write(Preferences.CheckForUpdates);
 
                 writer.Write(Preferences.Time);
-                
-                writer.Write((int)Preferences.ColorMode);
             }
 
             return output;

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -137,9 +137,9 @@ namespace Apollo.Components {
             UpdateCanvas();
             Hex.Text = Color.ToHex();
             
-            Red.Text = "" + Color.Red;
-            Green.Text = "" + Color.Green;
-            Blue.Text = "" + Color.Blue;
+            Red.Text = Color.Red.ToString();
+            Green.Text = Color.Green.ToString();
+            Blue.Text = Color.Blue.ToString();
         }
 
         void UpdateText() {
@@ -148,9 +148,9 @@ namespace Apollo.Components {
             
             Hex.Text = Color.ToHex();
             
-            Red.Text = "" + Color.Red;
-            Green.Text = "" + Color.Green;
-            Blue.Text = "" + Color.Blue;
+            Red.Text = Color.Red.ToString();
+            Green.Text = Color.Green.ToString();
+            Blue.Text = Color.Blue.ToString();
 
             hexValidation = true;
             rgbValidation = true;

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -378,9 +378,9 @@ namespace Apollo.Components {
 
                 Preview.Fill = Color.ToScreenBrush();
                 
-                hexValidation = false;
+                hexValidation = rgbValidation = false;
                 InitCanvas();
-                hexValidation = true;
+                hexValidation = rgbValidation = true;
             });
         }
         
@@ -414,9 +414,9 @@ namespace Apollo.Components {
                 
                 Preview.Fill = Color.ToScreenBrush();
                 
-                rgbValidation = false;
+                hexValidation = rgbValidation = false;
                 InitCanvas();
-                rgbValidation = true;
+                hexValidation = rgbValidation = true;
             });
         }
         

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -13,6 +13,7 @@ using LinearGradientBrush = Avalonia.Media.LinearGradientBrush;
 using GradientStop = Avalonia.Media.GradientStop;
 using IBrush = Avalonia.Media.IBrush;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 using Apollo.Core;
 using Apollo.Enums;
@@ -82,6 +83,8 @@ namespace Apollo.Components {
         void Update_ColorDisplayFormat() {
             Red.IsVisible = Green.IsVisible = Blue.IsVisible = Preferences.ColorDisplayFormat == ColorDisplayType.RGB;
             Hex.IsVisible = Preferences.ColorDisplayFormat == ColorDisplayType.Hex;
+
+            ((Window)this.GetVisualRoot())?.Focus();
         }
 
         bool hexValidation, rgbValidation;

--- a/Apollo/Components/ColorPicker.cs
+++ b/Apollo/Components/ColorPicker.cs
@@ -99,14 +99,14 @@ namespace Apollo.Components {
             observables.Add(Green.GetObservable(TextBox.TextProperty).Subscribe((string text) => RGB_Changed(text, "Green")));
             observables.Add(Blue.GetObservable(TextBox.TextProperty).Subscribe((string text) => RGB_Changed(text, "Blue")));
             
-            Preferences.ColorModeChanged += Update_ColorMode;
-            Update_ColorMode();
+            Preferences.ColorDisplayFormatChanged += Update_ColorDisplayFormat;
+            Update_ColorDisplayFormat();
         }
 
         void Unloaded(object sender, VisualTreeAttachmentEventArgs e) {
             ColorChanged = null;
             
-            Preferences.ColorModeChanged -= Update_ColorMode;
+            Preferences.ColorDisplayFormatChanged -= Update_ColorDisplayFormat;
 
             foreach (IDisposable observable in observables)
                 observable.Dispose();
@@ -183,22 +183,9 @@ namespace Apollo.Components {
             else              MainColor.Color = new AvaloniaColor(255, v, p, q);
         }
 
-        void Update_ColorMode(){
-            Red.IsVisible = false;
-            Green.IsVisible = false;
-            Blue.IsVisible = false;
-            Hex.IsVisible = false;
-            
-            switch(Preferences.ColorMode){
-            case ColorModeType.Hex:
-                Hex.IsVisible = true;
-                break;
-            case ColorModeType.RGB:
-                Red.IsVisible = true;
-                Green.IsVisible = true;
-                Blue.IsVisible = true;
-                break;         
-            }
+        void Update_ColorDisplayFormat() {
+            Red.IsVisible = Green.IsVisible = Blue.IsVisible = Preferences.ColorDisplayFormat == ColorDisplayType.RGB;
+            Hex.IsVisible = Preferences.ColorDisplayFormat == ColorDisplayType.Hex;
         }
 
         void Main_Move(object sender, PointerEventArgs e) {

--- a/Apollo/Components/ColorPicker.xaml
+++ b/Apollo/Components/ColorPicker.xaml
@@ -75,7 +75,16 @@
 
     <StackPanel Grid.Row="1" HorizontalAlignment="Center" Orientation="Horizontal" Margin="0 5 0 0">
       <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="70" Padding="2" x:Name="Hex"
-               KeyDown="Hex_KeyDown" LostFocus="Hex_Unfocus" PointerReleased="Hex_MouseUp" />
+               KeyDown="Text_KeyDown" LostFocus="Hex_Unfocus" PointerReleased="Hex_MouseUp" />
+      
+      <StackPanel Orientation="Horizontal" x:Name="RGB_Panel" Spacing="4">
+        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="30" Padding="2" x:Name="Red"
+          KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus"/>
+        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="30" Padding="2" x:Name="Green"
+          KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus"/>
+        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="30" Padding="2" x:Name="Blue"
+          KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus"/>
+      </StackPanel>
       
       <Canvas Margin="5 0 0 0" Width="15" Height="15" VerticalAlignment="Center">
         <Ellipse Width="15" Height="15" x:Name="Color" Fill="White" />

--- a/Apollo/Components/ColorPicker.xaml
+++ b/Apollo/Components/ColorPicker.xaml
@@ -78,12 +78,14 @@
                KeyDown="Text_KeyDown" LostFocus="Hex_Unfocus" PointerReleased="Hex_MouseUp" />
       
       <StackPanel Orientation="Horizontal" x:Name="RGB_Panel" Spacing="4">
-        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="30" Padding="2" x:Name="Red"
-          KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus"/>
-        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="30" Padding="2" x:Name="Green"
-          KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus"/>
-        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="30" Padding="2" x:Name="Blue"
-          KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus"/>
+        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="25" Padding="2" x:Name="Red"
+                 KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus" />
+
+        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="25" Padding="2" x:Name="Green"
+                 KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus" />
+
+        <TextBox Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="0 0 0 1" MinWidth="25" Padding="2" x:Name="Blue"
+                 KeyDown="Text_KeyDown" PointerReleased="RGB_MouseUp" LostFocus="RGB_Unfocus" />
       </StackPanel>
       
       <Canvas Margin="5 0 0 0" Width="15" Height="15" VerticalAlignment="Center">

--- a/Apollo/Core/Preferences.cs
+++ b/Apollo/Core/Preferences.cs
@@ -56,6 +56,19 @@ namespace Apollo.Core {
                 Save();
             }
         }
+        
+        public static event Changed ColorDisplayFormatChanged;
+        static ColorDisplayType _ColorDisplayFormat = ColorDisplayType.Hex;
+        public static ColorDisplayType ColorDisplayFormat {
+            get => _ColorDisplayFormat;
+            set {
+                _ColorDisplayFormat = value;
+                
+                ColorDisplayFormatChanged?.Invoke();
+                
+                Save();
+            }
+        }
 
         public static event Changed LaunchpadModelChanged;
         static LaunchpadModels _LaunchpadModel = LaunchpadModels.Pro;
@@ -314,19 +327,6 @@ namespace Apollo.Core {
             get => _CrashPath;
             set {
                 _CrashPath = value;
-                Save();
-            }
-        }
-        
-        public static event Changed ColorModeChanged;
-        static ColorModeType _ColorMode = ColorModeType.Hex;
-        public static ColorModeType ColorMode{
-            get => _ColorMode;
-            set {
-                _ColorMode = value;
-                
-                ColorModeChanged?.Invoke();
-                
                 Save();
             }
         }

--- a/Apollo/Core/Preferences.cs
+++ b/Apollo/Core/Preferences.cs
@@ -317,6 +317,19 @@ namespace Apollo.Core {
                 Save();
             }
         }
+        
+        public static event Changed ColorModeChanged;
+        static ColorModeType _ColorMode = ColorModeType.Hex;
+        public static ColorModeType ColorMode{
+            get => _ColorMode;
+            set {
+                _ColorMode = value;
+                
+                ColorModeChanged?.Invoke();
+                
+                Save();
+            }
+        }
 
         public static void Save() {
             if (!Directory.Exists(Program.UserPath)) Directory.CreateDirectory(Program.UserPath);

--- a/Apollo/Enums/Enums.cs
+++ b/Apollo/Enums/Enums.cs
@@ -6,6 +6,10 @@ namespace Apollo.Enums {
     public enum ThemeType {
         Dark, Light
     }
+    
+    public enum ColorModeType{
+        Hex, RGB
+    }
 
     public enum LaunchpadModels {
         MK2, Pro, X, All

--- a/Apollo/Enums/Enums.cs
+++ b/Apollo/Enums/Enums.cs
@@ -7,7 +7,7 @@ namespace Apollo.Enums {
         Dark, Light
     }
     
-    public enum ColorModeType{
+    public enum ColorDisplayType {
         Hex, RGB
     }
 

--- a/Apollo/Windows/PreferencesWindow.cs
+++ b/Apollo/Windows/PreferencesWindow.cs
@@ -32,6 +32,8 @@ namespace Apollo.Windows {
 
             ChainSignalIndicators = this.Get<CheckBox>("ChainSignalIndicators");
             DeviceSignalIndicators = this.Get<CheckBox>("DeviceSignalIndicators");
+            
+            ColorDisplayFormat = this.Get<ComboBox>("ColorDisplayFormat");
 
             LaunchpadStyle = this.Get<ComboBox>("LaunchpadStyle");
             LaunchpadGridRotation = this.Get<ComboBox>("LaunchpadGridRotation");
@@ -54,9 +56,6 @@ namespace Apollo.Windows {
             ThemeHeader = this.Get<TextBlock>("ThemeHeader");
             Dark = this.Get<RadioButton>("Dark");
             Light = this.Get<RadioButton>("Light");
-            
-            Hex = this.Get<RadioButton>("Hex");
-            RGB = this.Get<RadioButton>("RGB");
 
             Backup = this.Get<CheckBox>("Backup");
             Autosave = this.Get<CheckBox>("Autosave");
@@ -77,9 +76,9 @@ namespace Apollo.Windows {
         }
 
         CheckBox AlwaysOnTop, CenterTrackContents, ChainSignalIndicators, DeviceSignalIndicators, AutoCreateKeyFilter, AutoCreateMacroFilter, AutoCreatePattern, CopyPreviousFrame, CaptureLaunchpad, EnableGestures, Backup, Autosave, UndoLimit, DiscordPresence, DiscordFilename, CheckForUpdates;
-        ComboBox LaunchpadStyle, LaunchpadGridRotation, LaunchpadModel;
+        ComboBox ColorDisplayFormat, LaunchpadStyle, LaunchpadGridRotation, LaunchpadModel;
         TextBlock ThemeHeader, CurrentSession, AllTime;
-        RadioButton Monochrome, NovationPalette, CustomPalette, Dark, Light, Hex, RGB;
+        RadioButton Monochrome, NovationPalette, CustomPalette, Dark, Light;
         HorizontalDial FadeSmoothness;
         Controls Contents;
         DispatcherTimer Timer;
@@ -151,6 +150,8 @@ namespace Apollo.Windows {
 
             ChainSignalIndicators.IsChecked = Preferences.ChainSignalIndicators;
             DeviceSignalIndicators.IsChecked = Preferences.DeviceSignalIndicators;
+            
+            ColorDisplayFormat.SelectedIndex = (int)Preferences.ColorDisplayFormat;
 
             LaunchpadStyle.SelectedIndex = (int)Preferences.LaunchpadStyle;
             LaunchpadGridRotation.SelectedIndex = Convert.ToInt32(Preferences.LaunchpadGridRotation);
@@ -173,9 +174,6 @@ namespace Apollo.Windows {
 
             Dark.IsChecked = Preferences.Theme == ThemeType.Dark;
             Light.IsChecked = Preferences.Theme == ThemeType.Light;
-            
-            Hex.IsChecked = Preferences.ColorMode == ColorModeType.Hex;
-            RGB.IsChecked = Preferences.ColorMode == ColorModeType.RGB;
 
             Backup.IsChecked = Preferences.Backup;
             Autosave.IsChecked = Preferences.Autosave;
@@ -228,6 +226,8 @@ namespace Apollo.Windows {
         void ChainSignalIndicators_Changed(object sender, RoutedEventArgs e) => Preferences.ChainSignalIndicators = ChainSignalIndicators.IsChecked.Value;
 
         void DeviceSignalIndicators_Changed(object sender, RoutedEventArgs e) => Preferences.DeviceSignalIndicators = DeviceSignalIndicators.IsChecked.Value;
+
+        void ColorDisplayFormat_Changed(object sender, SelectionChangedEventArgs e) => Preferences.ColorDisplayFormat = (ColorDisplayType)ColorDisplayFormat.SelectedIndex;
         
         void LaunchpadStyle_Changed(object sender, SelectionChangedEventArgs e) => Preferences.LaunchpadStyle = (LaunchpadStyles)LaunchpadStyle.SelectedIndex;
 
@@ -298,9 +298,6 @@ namespace Apollo.Windows {
         void Dark_Changed(object sender, RoutedEventArgs e) => SetTheme(ThemeType.Dark);
 
         void Light_Changed(object sender, RoutedEventArgs e) => SetTheme(ThemeType.Light);
-
-        void Hex_Changed(object sender, RoutedEventArgs e) => Preferences.ColorMode = ColorModeType.Hex;
-        void RGB_Changed(object sender, RoutedEventArgs e) => Preferences.ColorMode = ColorModeType.RGB;
 
         void Backup_Changed(object sender, RoutedEventArgs e) => Preferences.Backup = Backup.IsChecked.Value;
 

--- a/Apollo/Windows/PreferencesWindow.cs
+++ b/Apollo/Windows/PreferencesWindow.cs
@@ -54,6 +54,9 @@ namespace Apollo.Windows {
             ThemeHeader = this.Get<TextBlock>("ThemeHeader");
             Dark = this.Get<RadioButton>("Dark");
             Light = this.Get<RadioButton>("Light");
+            
+            Hex = this.Get<RadioButton>("Hex");
+            RGB = this.Get<RadioButton>("RGB");
 
             Backup = this.Get<CheckBox>("Backup");
             Autosave = this.Get<CheckBox>("Autosave");
@@ -76,7 +79,7 @@ namespace Apollo.Windows {
         CheckBox AlwaysOnTop, CenterTrackContents, ChainSignalIndicators, DeviceSignalIndicators, AutoCreateKeyFilter, AutoCreateMacroFilter, AutoCreatePattern, CopyPreviousFrame, CaptureLaunchpad, EnableGestures, Backup, Autosave, UndoLimit, DiscordPresence, DiscordFilename, CheckForUpdates;
         ComboBox LaunchpadStyle, LaunchpadGridRotation, LaunchpadModel;
         TextBlock ThemeHeader, CurrentSession, AllTime;
-        RadioButton Monochrome, NovationPalette, CustomPalette, Dark, Light;
+        RadioButton Monochrome, NovationPalette, CustomPalette, Dark, Light, Hex, RGB;
         HorizontalDial FadeSmoothness;
         Controls Contents;
         DispatcherTimer Timer;
@@ -170,6 +173,9 @@ namespace Apollo.Windows {
 
             Dark.IsChecked = Preferences.Theme == ThemeType.Dark;
             Light.IsChecked = Preferences.Theme == ThemeType.Light;
+            
+            Hex.IsChecked = Preferences.ColorMode == ColorModeType.Hex;
+            RGB.IsChecked = Preferences.ColorMode == ColorModeType.RGB;
 
             Backup.IsChecked = Preferences.Backup;
             Autosave.IsChecked = Preferences.Autosave;
@@ -292,6 +298,9 @@ namespace Apollo.Windows {
         void Dark_Changed(object sender, RoutedEventArgs e) => SetTheme(ThemeType.Dark);
 
         void Light_Changed(object sender, RoutedEventArgs e) => SetTheme(ThemeType.Light);
+
+        void Hex_Changed(object sender, RoutedEventArgs e) => Preferences.ColorMode = ColorModeType.Hex;
+        void RGB_Changed(object sender, RoutedEventArgs e) => Preferences.ColorMode = ColorModeType.RGB;
 
         void Backup_Changed(object sender, RoutedEventArgs e) => Preferences.Backup = Backup.IsChecked.Value;
 

--- a/Apollo/Windows/PreferencesWindow.xaml
+++ b/Apollo/Windows/PreferencesWindow.xaml
@@ -64,6 +64,12 @@
 
                 <Border />
                 
+                <TextBlock Classes="heading" Text="Color Mode" />
+                <RadioButton GroupName="ColorMode" Click="Hex_Changed" x:Name="Hex">Hex</RadioButton>
+                <RadioButton GroupName="ColorMode" Click="RGB_Changed" x:Name="RGB">RGB</RadioButton>
+
+                <Border />
+                
                 <TextBlock Classes="heading" Text="Processing" />
                 <Components:HorizontalDial HorizontalAlignment="Left" x:Name="FadeSmoothness" Title="Fade Smoothness:" Minimum="0" Maximum="100" Default="1" Exponent="1" Round="0" Unit="%" Scale="0.4" 
                                            ValueChanged="FadeSmoothness_Changed"/>

--- a/Apollo/Windows/PreferencesWindow.xaml
+++ b/Apollo/Windows/PreferencesWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:Components="clr-namespace:Apollo.Components"
         Title="Preferences" WindowStartupLocation="CenterOwner" CanResize="false"
         Icon="/Resources/WindowIcon.png"
-        Width="420" MinWidth="420" MaxWidth="420"
+        Width="440" MinWidth="440" MaxWidth="440"
         Height="640" MinHeight="640" MaxHeight="640"
         Opened="Loaded" Closing="Unloaded"
         KeyDown="Window_KeyDown">
@@ -42,13 +42,28 @@
               </Style>
             </StackPanel.Styles>
 
-            <Grid ColumnDefinitions="*,Auto,Auto">
+            <Grid ColumnDefinitions="*,Auto,*">
+              <Grid.Styles>
+                <Style Selector="ComboBox">
+                  <Setter Property="BorderThickness" Value="0" />
+                  <Setter Property="Padding" Value="0" />
+                  <Setter Property="Background" Value="Transparent" />
+                </Style>
+              </Grid.Styles>
+
               <StackPanel Grid.Column="0" Spacing="5" VerticalAlignment="Center">
                 <TextBlock Classes="heading" Text="Appearance" />
                 <CheckBox Click="AlwaysOnTop_Changed" x:Name="AlwaysOnTop">Always on Top</CheckBox>
                 <CheckBox Click="CenterTrackContents_Changed" x:Name="CenterTrackContents">Center Track Contents</CheckBox>
                 <CheckBox Click="ChainSignalIndicators_Changed" x:Name="ChainSignalIndicators">Chain Signal Indicators</CheckBox>
                 <CheckBox Click="DeviceSignalIndicators_Changed" x:Name="DeviceSignalIndicators">Device Signal Indicators</CheckBox>
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                  <TextBlock Text="Color Display Format:" />
+                  <ComboBox x:Name="ColorDisplayFormat" SelectionChanged="ColorDisplayFormat_Changed">
+                    <ComboBoxItem>Hex</ComboBoxItem>
+                    <ComboBoxItem>RGB</ComboBoxItem>
+                  </ComboBox>
+                </StackPanel>
 
                 <Border />
 
@@ -64,28 +79,16 @@
 
                 <Border />
                 
-                <TextBlock Classes="heading" Text="Color Mode" />
-                <RadioButton GroupName="ColorMode" Click="Hex_Changed" x:Name="Hex">Hex</RadioButton>
-                <RadioButton GroupName="ColorMode" Click="RGB_Changed" x:Name="RGB">RGB</RadioButton>
-
-                <Border />
-                
                 <TextBlock Classes="heading" Text="Processing" />
                 <Components:HorizontalDial HorizontalAlignment="Left" x:Name="FadeSmoothness" Title="Fade Smoothness:" Minimum="0" Maximum="100" Default="1" Exponent="1" Round="0" Unit="%" Scale="0.4" 
                                            ValueChanged="FadeSmoothness_Changed"/>
+              </StackPanel>
 
-                <Border />
+              <Border Grid.Column="1" BorderBrush="{DynamicResource ThemeBorderHighBrush}" Margin="10 0" VerticalAlignment="Stretch" Width="2" BorderThickness="0 0 1 0" />
 
+              <StackPanel Grid.Column="2" Spacing="5" VerticalAlignment="Center">
                 <TextBlock Classes="heading" Text="On-screen Launchpad Style" />
                 <StackPanel Orientation="Horizontal">
-                  <StackPanel.Styles>
-                    <Style Selector="ComboBox">
-                      <Setter Property="BorderThickness" Value="0" />
-                      <Setter Property="Padding" Value="0" />
-                      <Setter Property="Background" Value="Transparent" />
-                    </Style>
-                  </StackPanel.Styles>
-
                   <ComboBox x:Name="LaunchpadGridRotation" SelectionChanged="LaunchpadGridRotation_Changed">
                     <ComboBoxItem>Standard</ComboBoxItem>
                     <ComboBoxItem>Diagonal</ComboBoxItem>
@@ -104,12 +107,9 @@
                     <ComboBoxItem>All</ComboBoxItem>
                   </ComboBox>
                 </StackPanel>
-              </StackPanel>
 
-              <Border Grid.Column="1" BorderBrush="{DynamicResource ThemeBorderHighBrush}" Margin="10 0" VerticalAlignment="Stretch" Width="2" BorderThickness="0 0 1 0" />
+                <Border />
 
-              <StackPanel Grid.Column="2" Spacing="5" VerticalAlignment="Center">
-                <TextBlock Classes="heading" Text="Launchpad Preview" />
                 <Components:LaunchpadGrid x:Name="Preview" PadPressed="Preview_Pressed" />
               </StackPanel>
             </Grid>


### PR DESCRIPTION
Closes #327, adding an option in Preferences to use RGB color values instead of hex values. If a value is empty when being edited, it will default to 0 when it loses focus. Not too sure about the UI and code might need some refactoring, but should work fine.