### PR TITLE
Implements Refresh device

### DIFF
--- a/Apollo/Binary/Common.cs
+++ b/Apollo/Binary/Common.cs
@@ -48,7 +48,8 @@ namespace Apollo.Binary {
             typeof(Choke),
             typeof(ColorFilter),
             typeof(Clear),
-            typeof(LayerFilter)
+            typeof(LayerFilter),
+            typeof(Refresh)
         };
     }
 }

--- a/Apollo/Binary/Decoder.cs
+++ b/Apollo/Binary/Decoder.cs
@@ -559,6 +559,9 @@ namespace Apollo.Binary {
                     (RotateType)reader.ReadInt32(),
                     reader.ReadBoolean()
                 );
+
+            else if (t == typeof(Refresh))
+                return new Refresh();
             
             else if (t == typeof(Switch)) {
                 int target = (version >= 25)? reader.ReadInt32() : 1;

--- a/Apollo/Binary/Decoder.cs
+++ b/Apollo/Binary/Decoder.cs
@@ -566,8 +566,9 @@ namespace Apollo.Binary {
                 );
 
             else if (t == typeof(Refresh)) 
-                return new Refresh((from i in Enumerable.Range(0, 4) select reader.ReadBoolean()).ToArray());
-                
+                return new Refresh(
+                    (from i in Enumerable.Range(0, 4) select reader.ReadBoolean()
+                ).ToArray());
             
             else if (t == typeof(Switch)) {
                 int target = (version >= 25)? reader.ReadInt32() : 1;

--- a/Apollo/Binary/Decoder.cs
+++ b/Apollo/Binary/Decoder.cs
@@ -565,12 +565,8 @@ namespace Apollo.Binary {
                     reader.ReadBoolean()
                 );
 
-            else if (t == typeof(Refresh)) {
-                bool[] macros;
-                macros = (from i in Enumerable.Range(0, 4) select reader.ReadBoolean()).ToArray();
-
-                return new Refresh(macros);
-            }
+            else if (t == typeof(Refresh)) 
+                return new Refresh((from i in Enumerable.Range(0, 4) select reader.ReadBoolean()).ToArray());
                 
             
             else if (t == typeof(Switch)) {

--- a/Apollo/Binary/Decoder.cs
+++ b/Apollo/Binary/Decoder.cs
@@ -565,8 +565,13 @@ namespace Apollo.Binary {
                     reader.ReadBoolean()
                 );
 
-            else if (t == typeof(Refresh))
-                return new Refresh();
+            else if (t == typeof(Refresh)) {
+                bool[] macros;
+                macros = (from i in Enumerable.Range(0, 4) select reader.ReadBoolean()).ToArray();
+
+                return new Refresh(macros);
+            }
+                
             
             else if (t == typeof(Switch)) {
                 int target = (version >= 25)? reader.ReadInt32() : 1;

--- a/Apollo/Binary/Encoder.cs
+++ b/Apollo/Binary/Encoder.cs
@@ -399,6 +399,10 @@ namespace Apollo.Binary {
             writer.Write(o.Bypass);
         }
 
+        static void Encode(BinaryWriter writer, Refresh o) {
+            EncodeID(writer, typeof(Refresh));
+        }
+
         static void Encode(BinaryWriter writer, Tone o) {
             EncodeID(writer, typeof(Tone));
 

--- a/Apollo/Binary/Encoder.cs
+++ b/Apollo/Binary/Encoder.cs
@@ -403,6 +403,8 @@ namespace Apollo.Binary {
 
         static void Encode(BinaryWriter writer, Refresh o) {
             EncodeID(writer, typeof(Refresh));
+
+            for (int i = 0; i < 4; i++) writer.Write(o.GetMacro(i));
         }
 
         static void Encode(BinaryWriter writer, Tone o) {

--- a/Apollo/Binary/Encoder.cs
+++ b/Apollo/Binary/Encoder.cs
@@ -404,7 +404,8 @@ namespace Apollo.Binary {
         static void Encode(BinaryWriter writer, Refresh o) {
             EncodeID(writer, typeof(Refresh));
 
-            for (int i = 0; i < 4; i++) writer.Write(o.GetMacro(i));
+            for (int i = 0; i < 4; i++)
+                writer.Write(o.GetMacro(i));
         }
 
         static void Encode(BinaryWriter writer, Tone o) {

--- a/Apollo/Components/DeviceAdd.xaml
+++ b/Apollo/Components/DeviceAdd.xaml
@@ -47,6 +47,7 @@
         <MenuItem Header="Preview" />
         <MenuItem Header="Switch" />
         <MenuItem Header="Clear" />
+        <MenuItem Header="Refresh" />
       </MenuItem>
     </Components:ApolloContextMenu>
 

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -16,7 +17,7 @@ namespace Apollo.DeviceViewers {
 
         void InitializeComponent(){
             AvaloniaXamlLoader.Load(this);
-            for (int i = 0; i < 4; i++) Macros[i] = this.Get<CheckBox>($"Macro_{i+1}");
+            Macros = (this.Get<StackPanel>("MacroStack")).Children.OfType<CheckBox>().ToArray();
         }
         
         Refresh _refresh;
@@ -31,9 +32,11 @@ namespace Apollo.DeviceViewers {
             for (int i = 0; i < 4; i++) Macros[i].IsChecked = _refresh.GetMacro(i);
         }
 
+        void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _refresh = null;
+
         void Macro_Changed(object sender, RoutedEventArgs e) {
             CheckBox source = (CheckBox)sender;
-            int index = ((StackPanel)source.Parent).Children.IndexOf(source);
+            int index = Array.IndexOf(Macros, source);
             bool value = source.IsChecked.Value;
 
             if (_refresh.GetMacro(index) != value) {
@@ -52,7 +55,5 @@ namespace Apollo.DeviceViewers {
         }
 
         public void SetMacro(int index, bool value) => Macros[index].IsChecked = value;
-
-        void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _refresh = null;
     }
 }

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -15,9 +15,9 @@ namespace Apollo.DeviceViewers {
     public class RefreshViewer: UserControl {
         public static readonly string DeviceIdentifier = "refresh";
 
-        void InitializeComponent(){
+        void InitializeComponent() {
             AvaloniaXamlLoader.Load(this);
-            Macros = (this.Get<StackPanel>("MacroStack")).Children.OfType<CheckBox>().ToArray();
+            Macros = ((StackPanel)Content).Children.OfType<CheckBox>().ToArray();
         }
         
         Refresh _refresh;
@@ -29,7 +29,9 @@ namespace Apollo.DeviceViewers {
             InitializeComponent();
 
             _refresh = refresh;
-            for (int i = 0; i < 4; i++) Macros[i].IsChecked = _refresh.GetMacro(i);
+            
+            for (int i = 0; i < 4; i++)
+                Macros[i].IsChecked = _refresh.GetMacro(i);
         }
 
         void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _refresh = null;
@@ -44,7 +46,7 @@ namespace Apollo.DeviceViewers {
                 bool r = value;
                 List<int> path = Track.GetPath(_refresh);
 
-                Program.Project.Undo.Add($"Refresh Macro {index+1} changed to {(r? "Enabled" : "Disabled")}", () => {
+                Program.Project.Undo.Add($"Refresh Macro {index + 1} changed to {(r? "Enabled" : "Disabled")}", () => {
                     Track.TraversePath<Refresh>(path).SetMacro(index, u);
                 }, () => {
                     Track.TraversePath<Refresh>(path).SetMacro(index, r);

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+using Apollo.Devices;
+using Apollo.Elements;
+using Apollo.Windows;
+
+namespace Apollo.DeviceViewers {
+    public class PatternViewer: UserControl {
+        public static readonly string DeviceIdentifier = "pattern";
+
+        void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+        
+        Pattern _pattern;
+
+        public PatternViewer() => new InvalidOperationException();
+
+        public PatternViewer(Pattern pattern) {
+            InitializeComponent();
+
+            _pattern = pattern;
+        }
+
+        void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _pattern = null;
+
+        void Pattern_Popout() => PatternWindow.Create(_pattern, Track.Get(_pattern)?.Window);
+    }
+}

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -9,23 +9,21 @@ using Apollo.Elements;
 using Apollo.Windows;
 
 namespace Apollo.DeviceViewers {
-    public class PatternViewer: UserControl {
-        public static readonly string DeviceIdentifier = "pattern";
+    public class RefreshViewer: UserControl {
+        public static readonly string DeviceIdentifier = "refresh";
 
         void InitializeComponent() => AvaloniaXamlLoader.Load(this);
         
-        Pattern _pattern;
+        Refresh _refresh;
 
-        public PatternViewer() => new InvalidOperationException();
+        public RefreshViewer() => new InvalidOperationException();
 
-        public PatternViewer(Pattern pattern) {
+        public RefreshViewer(Refresh refresh) {
             InitializeComponent();
 
-            _pattern = pattern;
+            _refresh = refresh;
         }
 
-        void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _pattern = null;
-
-        void Pattern_Popout() => PatternWindow.Create(_pattern, Track.Get(_pattern)?.Window);
+        void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _refresh = null;
     }
 }

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -1,12 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
 
+using Apollo.Core;
 using Apollo.Devices;
 using Apollo.Elements;
-using Apollo.Windows;
 
 namespace Apollo.DeviceViewers {
     public class RefreshViewer: UserControl {
@@ -15,6 +17,7 @@ namespace Apollo.DeviceViewers {
         void InitializeComponent() => AvaloniaXamlLoader.Load(this);
         
         Refresh _refresh;
+        StackPanel MacroStack = new StackPanel();
 
         public RefreshViewer() => new InvalidOperationException();
 
@@ -23,6 +26,28 @@ namespace Apollo.DeviceViewers {
 
             _refresh = refresh;
         }
+
+        void Macro_Changed(object sender, RoutedEventArgs e) {
+            CheckBox source = (CheckBox)sender;
+            int index = ((StackPanel)source.Parent).Children.IndexOf(source);
+            bool value = source.IsChecked.Value;
+
+            if (_refresh.GetMacro(index) != value) {
+                bool u = value;
+                bool r = _refresh.GetMacro(index);
+                List<int> path = Track.GetPath(_refresh);
+
+                Program.Project.Undo.Add($"Refresh Macro {index} changed to {(r? "Enabled" : "Disabled")}", () => {
+                    Track.TraversePath<Refresh>(path).SetMacro(index, u);
+                }, () => {
+                    Track.TraversePath<Refresh>(path).SetMacro(index, r);
+                });
+
+                SetMacro(index, value);
+            }
+        }
+
+        public void SetMacro(int index, bool value) => _refresh.SetMacro(index, value);
 
         void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _refresh = null;
     }

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -14,10 +14,13 @@ namespace Apollo.DeviceViewers {
     public class RefreshViewer: UserControl {
         public static readonly string DeviceIdentifier = "refresh";
 
-        void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+        void InitializeComponent(){
+            AvaloniaXamlLoader.Load(this);
+            for (int i = 0; i < 4; i++) Macros[i] = this.Get<CheckBox>($"Macro_{i+1}");
+        }
         
         Refresh _refresh;
-        StackPanel MacroStack = new StackPanel();
+        CheckBox[] Macros = new CheckBox[4];
 
         public RefreshViewer() => new InvalidOperationException();
 
@@ -25,6 +28,7 @@ namespace Apollo.DeviceViewers {
             InitializeComponent();
 
             _refresh = refresh;
+            for (int i = 0; i < 4; i++) Macros[i].IsChecked = _refresh.GetMacro(i);
         }
 
         void Macro_Changed(object sender, RoutedEventArgs e) {
@@ -33,8 +37,8 @@ namespace Apollo.DeviceViewers {
             bool value = source.IsChecked.Value;
 
             if (_refresh.GetMacro(index) != value) {
-                bool u = value;
-                bool r = _refresh.GetMacro(index);
+                bool u = _refresh.GetMacro(index);
+                bool r = value;
                 List<int> path = Track.GetPath(_refresh);
 
                 Program.Project.Undo.Add($"Refresh Macro {index} changed to {(r? "Enabled" : "Disabled")}", () => {
@@ -43,11 +47,11 @@ namespace Apollo.DeviceViewers {
                     Track.TraversePath<Refresh>(path).SetMacro(index, r);
                 });
 
-                SetMacro(index, value);
+                _refresh.SetMacro(index, value);
             }
         }
 
-        public void SetMacro(int index, bool value) => _refresh.SetMacro(index, value);
+        public void SetMacro(int index, bool value) => Macros[index].IsChecked = value;
 
         void Unloaded(object sender, VisualTreeAttachmentEventArgs e) => _refresh = null;
     }

--- a/Apollo/DeviceViewers/RefreshViewer.cs
+++ b/Apollo/DeviceViewers/RefreshViewer.cs
@@ -41,7 +41,7 @@ namespace Apollo.DeviceViewers {
                 bool r = value;
                 List<int> path = Track.GetPath(_refresh);
 
-                Program.Project.Undo.Add($"Refresh Macro {index} changed to {(r? "Enabled" : "Disabled")}", () => {
+                Program.Project.Undo.Add($"Refresh Macro {index+1} changed to {(r? "Enabled" : "Disabled")}", () => {
                     Track.TraversePath<Refresh>(path).SetMacro(index, u);
                 }, () => {
                     Track.TraversePath<Refresh>(path).SetMacro(index, r);

--- a/Apollo/DeviceViewers/RefreshViewer.xaml
+++ b/Apollo/DeviceViewers/RefreshViewer.xaml
@@ -1,16 +1,13 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Apollo.DeviceViewers.RefreshViewer"
-             xmlns:Components="clr-namespace:Apollo.Components"
              Margin="10 5"
              DetachedFromVisualTree="Unloaded">
 
-    <Grid>
-        <StackPanel x:Name="MacroStack" VerticalAlignment="Center" Spacing="10">
-            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 1</CheckBox>
-            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 2</CheckBox>
-            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 3</CheckBox>
-            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 4</CheckBox>
-        </StackPanel>
-    </Grid>
+  <StackPanel VerticalAlignment="Center" Spacing="5" Margin="5 0">
+    <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 1</CheckBox>
+    <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 2</CheckBox>
+    <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 3</CheckBox>
+    <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 4</CheckBox>
+  </StackPanel>
 </UserControl>

--- a/Apollo/DeviceViewers/RefreshViewer.xaml
+++ b/Apollo/DeviceViewers/RefreshViewer.xaml
@@ -4,4 +4,13 @@
              xmlns:Components="clr-namespace:Apollo.Components"
              Margin="10 5"
              DetachedFromVisualTree="Unloaded">
+
+    <Grid>
+        <StackPanel x:Name="MacroStack" VerticalAlignment="Center" Spacing="10">
+            <CheckBox HorizontalAlignment="Center" x:Name="Macro_1" Click="Macro_Changed">Macro 1</CheckBox>
+            <CheckBox HorizontalAlignment="Center" x:Name="Macro_2" Click="Macro_Changed">Macro 2</CheckBox>
+            <CheckBox HorizontalAlignment="Center" x:Name="Macro_3" Click="Macro_Changed">Macro 3</CheckBox>
+            <CheckBox HorizontalAlignment="Center" x:Name="Macro_4" Click="Macro_Changed">Macro 4</CheckBox>
+        </StackPanel>
+    </Grid>
 </UserControl>

--- a/Apollo/DeviceViewers/RefreshViewer.xaml
+++ b/Apollo/DeviceViewers/RefreshViewer.xaml
@@ -1,9 +1,7 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="Apollo.DeviceViewers.PatternViewer"
+             x:Class="Apollo.DeviceViewers.RefreshViewer"
              xmlns:Components="clr-namespace:Apollo.Components"
              Margin="10 5"
              DetachedFromVisualTree="Unloaded">
-  
-  <Components:LargePopout Width="44" HorizontalAlignment="Center" VerticalAlignment="Center" Clicked="Pattern_Popout" />
 </UserControl>

--- a/Apollo/DeviceViewers/RefreshViewer.xaml
+++ b/Apollo/DeviceViewers/RefreshViewer.xaml
@@ -6,7 +6,7 @@
              DetachedFromVisualTree="Unloaded">
 
     <Grid>
-        <StackPanel VerticalAlignment="Center" Spacing="10">
+        <StackPanel x:Name="MacroStack" VerticalAlignment="Center" Spacing="10">
             <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 1</CheckBox>
             <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 2</CheckBox>
             <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 3</CheckBox>

--- a/Apollo/DeviceViewers/RefreshViewer.xaml
+++ b/Apollo/DeviceViewers/RefreshViewer.xaml
@@ -6,11 +6,11 @@
              DetachedFromVisualTree="Unloaded">
 
     <Grid>
-        <StackPanel x:Name="MacroStack" VerticalAlignment="Center" Spacing="10">
-            <CheckBox HorizontalAlignment="Center" x:Name="Macro_1" Click="Macro_Changed">Macro 1</CheckBox>
-            <CheckBox HorizontalAlignment="Center" x:Name="Macro_2" Click="Macro_Changed">Macro 2</CheckBox>
-            <CheckBox HorizontalAlignment="Center" x:Name="Macro_3" Click="Macro_Changed">Macro 3</CheckBox>
-            <CheckBox HorizontalAlignment="Center" x:Name="Macro_4" Click="Macro_Changed">Macro 4</CheckBox>
+        <StackPanel VerticalAlignment="Center" Spacing="10">
+            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 1</CheckBox>
+            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 2</CheckBox>
+            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 3</CheckBox>
+            <CheckBox HorizontalAlignment="Center" Click="Macro_Changed">Macro 4</CheckBox>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Apollo/DeviceViewers/RefreshViewer.xaml
+++ b/Apollo/DeviceViewers/RefreshViewer.xaml
@@ -1,0 +1,9 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Apollo.DeviceViewers.PatternViewer"
+             xmlns:Components="clr-namespace:Apollo.Components"
+             Margin="10 5"
+             DetachedFromVisualTree="Unloaded">
+  
+  <Components:LargePopout Width="44" HorizontalAlignment="Center" VerticalAlignment="Center" Clicked="Pattern_Popout" />
+</UserControl>

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -11,6 +11,13 @@ namespace Apollo.Devices {
             Enabled = Enabled
         };
 
+        bool[] _macros = new bool[4];
+        public bool GetMacro(int index) => _macros[index];
+        public void SetMacro(int index, bool macro) {
+            _macros[index] = macro;
+            if (Viewer?.SpecificViewer != null) ((RefreshViewer)Viewer.SpecificViewer).SetMacro(index, macro);
+        }
+
         public Refresh(): base("refresh") {}
 
         public override void MIDIProcess(Signal n) {

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -21,7 +21,10 @@ namespace Apollo.Devices {
         public Refresh(): base("refresh") {}
 
         public override void MIDIProcess(Signal n) {
-            n.Macros = (int[])Program.Project.Macros.Clone();
+            for (int i = 0; i < 4; i++) {
+                if (_macros[i] == true) n.Macros[i] = (int)Program.Project.GetMacro(i+1);
+            }
+            
             InvokeExit(n);
         }
     }

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -18,7 +18,11 @@ namespace Apollo.Devices {
             if (Viewer?.SpecificViewer != null) ((RefreshViewer)Viewer.SpecificViewer).SetMacro(index, macro);
         }
 
-        public Refresh(): base("refresh") {}
+        public Refresh(bool[] macros = null): base("refresh") {
+            if (macros != null) {
+                for (int i = 0; i < 4; i++) SetMacro(i, macros[i]);
+            }
+        }
 
         public override void MIDIProcess(Signal n) {
             for (int i = 0; i < 4; i++) {

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -1,0 +1,31 @@
+using Apollo.DeviceViewers;
+using Apollo.Elements;
+using Apollo.Structures;
+
+namespace Apollo.Devices {
+    public class Paint: Device {
+        Color _color;
+        public Color Color {
+            get => _color;
+            set {
+                if (_color != value) {
+                    _color = value;
+
+                    if (Viewer?.SpecificViewer != null) ((PaintViewer)Viewer.SpecificViewer).Set(Color);
+                }
+            }
+        }
+
+        public override Device Clone() => new Paint(Color.Clone()) {
+            Collapsed = Collapsed,
+            Enabled = Enabled
+        };
+
+        public Paint(Color color = null): base("paint") => Color = color?? new Color();
+
+        public override void MIDIProcess(Signal n) {
+            if (n.Color.Lit) n.Color = Color.Clone();
+            InvokeExit(n);
+        }
+    }
+}

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -28,7 +28,8 @@ namespace Apollo.Devices {
 
         public override void MIDIProcess(Signal n) {
             for (int i = 0; i < 4; i++) {
-                if (_macros[i]) n.Macros[i] = (int)Program.Project.GetMacro(i+1);
+                if (_macros[i])
+                    n.Macros[i] = (int)Program.Project.GetMacro(i + 1);
             }
             
             InvokeExit(n);

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -19,14 +19,13 @@ namespace Apollo.Devices {
         }
 
         public Refresh(bool[] macros = null): base("refresh") {
-            if (macros != null) {
-                for (int i = 0; i < 4; i++) SetMacro(i, macros[i]);
-            }
+            if (macros == null || macros.Length != 4) macros = new bool[4];
+            _macros = macros;
         }
 
         public override void MIDIProcess(Signal n) {
             for (int i = 0; i < 4; i++) {
-                if (_macros[i] == true) n.Macros[i] = (int)Program.Project.GetMacro(i+1);
+                if (_macros[i]) n.Macros[i] = (int)Program.Project.GetMacro(i+1);
             }
             
             InvokeExit(n);

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Apollo.DeviceViewers;
 using Apollo.Elements;
 using Apollo.Structures;
@@ -5,18 +7,19 @@ using Apollo.Core;
 
 namespace Apollo.Devices {
     public class Refresh: Device {
-
-        public override Device Clone() => new Refresh() {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
-
         bool[] _macros = new bool[4];
+
         public bool GetMacro(int index) => _macros[index];
         public void SetMacro(int index, bool macro) {
             _macros[index] = macro;
+
             if (Viewer?.SpecificViewer != null) ((RefreshViewer)Viewer.SpecificViewer).SetMacro(index, macro);
         }
+        
+        public override Device Clone() => new Refresh(_macros.ToArray()) {
+            Collapsed = Collapsed,
+            Enabled = Enabled
+        };
 
         public Refresh(bool[] macros = null): base("refresh") {
             if (macros == null || macros.Length != 4) macros = new bool[4];

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -1,6 +1,7 @@
 using Apollo.DeviceViewers;
 using Apollo.Elements;
 using Apollo.Structures;
+using Apollo.Core;
 
 namespace Apollo.Devices {
     public class Refresh: Device {
@@ -10,10 +11,10 @@ namespace Apollo.Devices {
             Enabled = Enabled
         };
 
-        public Refresh();
+        public Refresh(): base("refresh") {}
 
         public override void MIDIProcess(Signal n) {
-            
+            n.Macros = (int[])Program.Project.Macros.Clone();
             InvokeExit(n);
         }
     }

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -3,28 +3,17 @@ using Apollo.Elements;
 using Apollo.Structures;
 
 namespace Apollo.Devices {
-    public class Paint: Device {
-        Color _color;
-        public Color Color {
-            get => _color;
-            set {
-                if (_color != value) {
-                    _color = value;
+    public class Refresh: Device {
 
-                    if (Viewer?.SpecificViewer != null) ((PaintViewer)Viewer.SpecificViewer).Set(Color);
-                }
-            }
-        }
-
-        public override Device Clone() => new Paint(Color.Clone()) {
+        public override Device Clone() => new Refresh() {
             Collapsed = Collapsed,
             Enabled = Enabled
         };
 
-        public Paint(Color color = null): base("paint") => Color = color?? new Color();
+        public Refresh();
 
         public override void MIDIProcess(Signal n) {
-            if (n.Color.Lit) n.Color = Color.Clone();
+            
             InvokeExit(n);
         }
     }


### PR DESCRIPTION
Fixes #328 by implementing a Refresh device that lets users refresh one or multiple of the Macro values attached to a Signal while it is passing through the chain, allowing for dynamic light effects.