### PR TITLE
Launchpad: Clear Screen instead of making a new one

### DIFF
--- a/Apollo/Elements/AbletonLaunchpad.cs
+++ b/Apollo/Elements/AbletonLaunchpad.cs
@@ -45,13 +45,6 @@ namespace Apollo.Elements {
             
             Target?.Clear(manual);
 
-            Signal n = new Signal(this, this, 0, new Color(0));
-
-            for (int i = 0; i < 100; i++) {
-                n.Index = (byte)i;
-                Window?.SignalRender(n);
-            }
-
             if (Version >= 1)
                 AbletonConnector.SendClear(this);
         }

--- a/Apollo/Elements/Launchpad.cs
+++ b/Apollo/Elements/Launchpad.cs
@@ -141,14 +141,6 @@ namespace Apollo.Elements {
             {LaunchpadType.MiniMK3, NovationHeader.Concat(new byte[] {0x0D, 0x03, 0x03}).ToArray()}
         };
 
-        static Dictionary<LaunchpadType, byte[]> ClearMessage = new Dictionary<LaunchpadType, byte[]>() {
-            {LaunchpadType.MK2, NovationHeader.Concat(new byte[] {0x18, 0x0E, 0x00}).ToArray()},
-            {LaunchpadType.PRO, NovationHeader.Concat(new byte[] {0x10, 0x0E, 0x00}).ToArray()},
-            {LaunchpadType.CFW, NovationHeader.Concat(new byte[] {0x10, 0x0E, 0x00}).ToArray()},
-            {LaunchpadType.X, NovationHeader.Concat(new byte[] {0x0C, 0x02, 0x00}).ToArray()},
-            {LaunchpadType.MiniMK3, NovationHeader.Concat(new byte[] {0x0D, 0x02, 0x00}).ToArray()}
-        };
-
         InputType _format = InputType.DrumRack;
         public InputType InputFormat {
             get => _format;
@@ -183,17 +175,19 @@ namespace Apollo.Elements {
 
         protected void InvokeReceive(Signal n) => Receive?.Invoke(n);
 
-        protected Screen screen;
+        protected Screen screen = new Screen();
         ConcurrentQueue<SysExMessage> buffer;
         object locker;
         int[][] inputbuffer;
         ulong signalCount = 0;
 
         protected void CreateScreen() {
-            screen = new Screen() { ScreenExit = Send };
             buffer = new ConcurrentQueue<SysExMessage>();
             locker = new object();
             inputbuffer = Enumerable.Range(0, 101).Select(i => (int[])null).ToArray();
+
+            screen.ScreenExit = Send;
+            screen.Clear();
         }
 
         public Color GetColor(int index) => (PatternWindow == null)
@@ -377,17 +371,6 @@ namespace Apollo.Elements {
             if (!Usable || (manual && PatternWindow != null)) return;
 
             CreateScreen();
-
-            Signal n = new Signal(this, this, 0, new Color(0));
-
-            for (int i = 0; i < 101; i++) {
-                n.Index = (byte)i;
-                Window?.SignalRender(n.Clone());
-            }
-
-            SysExSend(ClearMessage[Type]);
-            
-            if (HasModeLight) Send(n); // Clear Mode Light
         }
 
         public virtual void Render(Signal n) {

--- a/Apollo/Elements/VirtualLaunchpad.cs
+++ b/Apollo/Elements/VirtualLaunchpad.cs
@@ -10,19 +10,6 @@ namespace Apollo.Elements {
 
         public override void Send(Signal n) => Window?.SignalRender(n);
 
-        public override void Clear(bool manual = false) {
-            if (!Available || (manual && PatternWindow != null)) return;
-            
-            CreateScreen();
-
-            Signal n = new Signal(this, this, 0, new Color(0));
-
-            for (int i = 0; i < 101; i++) {
-                n.Index = (byte)i;
-                Window?.SignalRender(n.Clone());
-            }
-        }
-
         public VirtualLaunchpad(string name, int index) {
             Type = LaunchpadType.PRO;
             Name = name;

--- a/Apollo/Structures/Screen.cs
+++ b/Apollo/Structures/Screen.cs
@@ -7,16 +7,28 @@ namespace Apollo.Structures {
     public class Screen {
         class Pixel {
             public Action<Signal> Exit = null;
+
+            byte Index;
             
-            SortedList<int, Signal> _signals = new SortedList<int, Signal>() {
-                [10000] = new Signal(null, null, color: new Color(0), layer: -100)
-            };
+            SortedList<int, Signal> _signals = new SortedList<int, Signal>();
             
             Color state = new Color(0);
 
             object locker = new object();
 
-            public Pixel() {}
+            public void Clear() {
+                lock (locker) {
+                    _signals.Clear();
+                    _signals.Add(10000, new Signal(null, null, color: new Color(0), layer: -100));
+
+                    Update();
+                }
+            }
+
+            public Pixel(int index) {
+                Index = (byte)index;
+                Clear();
+            }
 
             public Color GetColor() {
                 Color ret = new Color(0);
@@ -36,21 +48,26 @@ namespace Apollo.Structures {
                 return ret;
             }
 
+            void Update() {
+                Color newState = GetColor();
+                    
+                if (newState != state) {
+                    state = newState;
+                    Exit?.Invoke(new Signal(null, null, Index, newState));
+                }
+            }
+
             public void MIDIEnter(Signal n) {
                 lock (locker) {
+                    if (n.Index != Index) return;
+
                     int layer = -n.Layer;
 
                     if (n.Color.Lit) _signals[layer] = n.Clone();
                     else if (_signals.ContainsKey(layer)) _signals.Remove(layer);
                     else return;
 
-                    Color newState = GetColor();
-                    
-                    if (newState != state) {
-                        Signal m = n.Clone();
-                        m.Color = state = newState;
-                        Exit?.Invoke(m);
-                    }
+                    Update();
                 }
             }
         }
@@ -59,9 +76,14 @@ namespace Apollo.Structures {
 
         Pixel[] _screen = new Pixel[101];
 
+        public void Clear() {
+            foreach (Pixel pixel in _screen)
+                pixel.Clear();
+        }
+
         public Screen() {
             for (int i = 0; i < 101; i++)
-                _screen[i] = new Pixel() { Exit = (n) => ScreenExit?.Invoke(n) };
+                _screen[i] = new Pixel(i) { Exit = n => ScreenExit?.Invoke(n) };
         }
 
         public Color GetColor(int index) => _screen[index].GetColor();


### PR DESCRIPTION
This lets Screen handle clearing the Launchpad (clearing what buttons it thinks are clearable) instead of force clearing everything.

We need this because the Pro MK3 (#367) doesn't have a dedicated clear message, and any attempt to force clear via lots of LED set messages resulted in odd delays and lags only when testing with the Pro MK3 (i.e. other Launchpads were unaffected).