### PR TITLE
Implement Purpose field for Devices to achieve proper initialization

### DIFF
--- a/Apollo/DeviceViewers/GroupViewer.cs
+++ b/Apollo/DeviceViewers/GroupViewer.cs
@@ -12,6 +12,7 @@ using Apollo.Components;
 using Apollo.Core;
 using Apollo.Devices;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Selection;
 using Apollo.Viewers;
 
@@ -136,9 +137,9 @@ namespace Apollo.DeviceViewers {
             Chain chain = new Chain();
 
             if (_group.GetType() == typeof(Group)) {
-                if (Preferences.AutoCreateMacroFilter) chain.Add(new MacroFilter());
-                if (Preferences.AutoCreateKeyFilter) chain.Add(new KeyFilter());
-                if (Preferences.AutoCreatePattern) chain.Add(new Pattern());
+                if (Preferences.AutoCreateMacroFilter) chain.Add(Device.Create<MacroFilter>(PurposeType.Active));
+                if (Preferences.AutoCreateKeyFilter) chain.Add(Device.Create<KeyFilter>(PurposeType.Active));
+                if (Preferences.AutoCreatePattern) chain.Add(Device.Create<Pattern>(PurposeType.Active));
             }
 
             Chain_Insert(index, chain);

--- a/Apollo/Devices/Choke.cs
+++ b/Apollo/Devices/Choke.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -61,10 +62,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Choke(Target, Chain.Clone()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Target, Chain.Clone(purpose) };
 
         public Choke(int target = 1, Chain chain = null): base("choke") {
             Target = target;

--- a/Apollo/Devices/Clear.cs
+++ b/Apollo/Devices/Clear.cs
@@ -21,10 +21,8 @@ namespace Apollo.Devices {
             }
         }
         
-        public override Device Clone() => new Clear(Mode) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Mode };
 
         public Clear(ClearType mode = ClearType.Lights): base("clear") => Mode = mode;
 

--- a/Apollo/Devices/ColorFilter.cs
+++ b/Apollo/Devices/ColorFilter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -78,10 +79,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new ColorFilter(Hue, Saturation, Value, HueTolerance, SaturationTolerance, ValueTolerance) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Hue, Saturation, Value, HueTolerance, SaturationTolerance, ValueTolerance };
 
         public ColorFilter(double hue = 0, double saturation = 1, double value = 1, double hue_t = 0.05, double saturation_t = 0.05, double value_t = 0.05): base("colorfilter", "Color Filter") {
             Hue = hue;

--- a/Apollo/Devices/Copy.cs
+++ b/Apollo/Devices/Copy.cs
@@ -175,10 +175,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Copy(_time.Clone(), _gate, Pinch, Bilateral, Reverse, Infinite, CopyMode, GridMode, Wrap, Offsets.Select(i => i.Clone()).ToList(), Angles.ToList()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { _time.Clone(), _gate, Pinch, Bilateral, Reverse, Infinite, CopyMode, GridMode, Wrap, Offsets.Select(i => i.Clone()).ToList(), Angles.ToList() };
 
         public Copy(Time time = null, double gate = 1, double pinch = 0, bool bilateral = false, bool reverse = false, bool infinite = false, CopyType copymode = CopyType.Static, GridType gridmode = GridType.Full, bool wrap = false, List<Offset> offsets = null, List<int> angles = null): base("copy") {
             Time = time?? new Time(free: 500);
@@ -613,7 +611,7 @@ namespace Apollo.Devices {
             
             OffsetRemoveUndoEntry(BinaryReader reader, int version): base(reader, version) {
                 index = reader.ReadInt32();
-                offset = Decoder.Decode<Offset>(reader, version);
+                offset = Decoder.Decode<Offset>(reader, version, PurposeType.Passive);
                 angle = reader.ReadInt32();
             }
             

--- a/Apollo/Devices/Delay.cs
+++ b/Apollo/Devices/Delay.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Rendering;
 using Apollo.Structures;
 using Apollo.Undo;
@@ -56,10 +57,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Delay(_time.Clone(), _gate) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { _time.Clone(), _gate };
 
         public Delay(Time time = null, double gate = 1): base("delay") {
             Time = time?? new Time();

--- a/Apollo/Devices/Fade.cs
+++ b/Apollo/Devices/Fade.cs
@@ -333,7 +333,8 @@ namespace Apollo.Devices {
                         }
                     };
 
-                    if (fade == null) Initialize();
+                    if (fade == null)
+                        throw new Exception("Fade was never initialized");
 
                     Schedule(Next, start += fade[1].Time - fade[0].Time);
 

--- a/Apollo/Devices/Fade.cs
+++ b/Apollo/Devices/Fade.cs
@@ -243,10 +243,8 @@ namespace Apollo.Devices {
 
         public int Count => _colors.Count;
 
-        public override Device Clone() => new Fade(_time.Clone(), _gate, PlayMode, _colors.Select(i => i.Clone()).ToList(), _positions.ToList(), _types.ToList()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { _time.Clone(), _gate, PlayMode, _colors.Select(i => i.Clone()).ToList(), _positions.ToList(), _types.ToList() };
 
         public void Insert(int index, Color color, double position, FadeType type) {
             _colors.Insert(index, color);
@@ -289,9 +287,13 @@ namespace Apollo.Devices {
         }
 
         protected override void Initialized() {
+            if (Purpose != PurposeType.Active || Purpose != PurposeType.Unrelated) return;
+
             Generate();
 
             Preferences.FPSLimitChanged += Generate;
+
+            if (Purpose != PurposeType.Active) return;
 
             if (Program.Project != null)
                 Program.Project.BPMChanged += Generate;
@@ -354,7 +356,7 @@ namespace Apollo.Devices {
             Generated = null;
             Preferences.FPSLimitChanged -= Generate;
 
-            if (Program.Project != null)
+            if (Purpose == PurposeType.Active && Program.Project != null)
                 Program.Project.BPMChanged -= Generate;
 
             Time.Dispose();
@@ -381,7 +383,7 @@ namespace Apollo.Devices {
             ThumbInsertUndoEntry(BinaryReader reader, int version)
             : base(reader, version) {
                 index = reader.ReadInt32();
-                thumbColor = Decoder.Decode<Color>(reader, version);
+                thumbColor = Decoder.Decode<Color>(reader, version, PurposeType.Passive);
                 pos = reader.ReadDouble();
                 type = (FadeType)reader.ReadInt32();
             }
@@ -416,7 +418,7 @@ namespace Apollo.Devices {
             
             ThumbRemoveUndoEntry(BinaryReader reader, int version): base(reader, version){
                 index = reader.ReadInt32();
-                uc = Decoder.Decode<Color>(reader, version);
+                uc = Decoder.Decode<Color>(reader, version, PurposeType.Passive);
                 up = reader.ReadDouble();
                 ut = (FadeType)reader.ReadInt32();
             }
@@ -581,7 +583,7 @@ namespace Apollo.Devices {
         
             protected CutUndoEntry(BinaryReader reader, int version)
             : base(reader, version) {
-                colors = Enumerable.Range(0, reader.ReadInt32()).Select(i => Decoder.Decode<Color>(reader, version)).ToList();
+                colors = Enumerable.Range(0, reader.ReadInt32()).Select(i => Decoder.Decode<Color>(reader, version, PurposeType.Passive)).ToList();
                 positions = Enumerable.Range(0, reader.ReadInt32()).Select(i => reader.ReadDouble()).ToList();
                 fadetypes = Enumerable.Range(0, reader.ReadInt32()).Select(i => (FadeType)reader.ReadInt32()).ToList();
                 index = reader.ReadInt32();

--- a/Apollo/Devices/Fade.cs
+++ b/Apollo/Devices/Fade.cs
@@ -287,7 +287,7 @@ namespace Apollo.Devices {
         }
 
         protected override void Initialized() {
-            if (Purpose != PurposeType.Active || Purpose != PurposeType.Unrelated) return;
+            if (Purpose != PurposeType.Active && Purpose != PurposeType.Unrelated) return;
 
             Generate();
 

--- a/Apollo/Devices/Fade.cs
+++ b/Apollo/Devices/Fade.cs
@@ -244,7 +244,7 @@ namespace Apollo.Devices {
         public int Count => _colors.Count;
 
         protected override object[] CloneParameters(PurposeType purpose)
-            => new object[] { _time.Clone(), _gate, PlayMode, _colors.Select(i => i.Clone()).ToList(), _positions.ToList(), _types.ToList() };
+            => new object[] { _time.Clone(), _gate, PlayMode, _colors.Select(i => i.Clone()).ToList(), _positions.ToList(), _types.ToList(), Type.Missing };
 
         public void Insert(int index, Color color, double position, FadeType type) {
             _colors.Insert(index, color);

--- a/Apollo/Devices/Flip.cs
+++ b/Apollo/Devices/Flip.cs
@@ -31,10 +31,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Flip(Mode, Bypass) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Mode, Bypass };
 
         public Flip(FlipType mode = FlipType.Horizontal, bool bypass = false): base("flip") {
             Mode = mode;

--- a/Apollo/Devices/Group.cs
+++ b/Apollo/Devices/Group.cs
@@ -88,7 +88,7 @@ namespace Apollo.Devices {
         }
 
         protected override object[] CloneParameters(PurposeType purpose)
-            => new object[] { Chains.Select(i => i.Clone(purpose)).ToList(), Expanded };
+            => new object[] { Chains.Select(i => i.Clone(purpose)).ToList(), Expanded, Type.Missing };
 
         public Group(List<Chain> init = null, int? expanded = null, string identifier = "group"): base(identifier) {
             foreach (Chain chain in init?? new List<Chain>()) Chains.Add(chain);

--- a/Apollo/Devices/Hold.cs
+++ b/Apollo/Devices/Hold.cs
@@ -84,10 +84,8 @@ namespace Apollo.Devices {
 
         bool ActualRelease => HoldMode == HoldType.Minimum? false : Release;
 
-        public override Device Clone() => new Hold(_time.Clone(), _gate, HoldMode, Release) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { _time.Clone(), _gate, HoldMode, Release };
 
         public Hold(Time time = null, double gate = 1, HoldType holdmode = HoldType.Trigger, bool release = false): base("hold") {
             Time = time?? new Time();

--- a/Apollo/Devices/KeyFilter.cs
+++ b/Apollo/Devices/KeyFilter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -21,11 +22,9 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new KeyFilter(_filter.ToArray()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
-
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { _filter.ToArray() };
+        
         public bool this[int index] {
             get => _filter[index];
             set {

--- a/Apollo/Devices/Layer.cs
+++ b/Apollo/Devices/Layer.cs
@@ -43,10 +43,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Layer(Target, BlendingMode, Range) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Target, BlendingMode, Range };
 
         public Layer(int target = 0, BlendingType blending = BlendingType.Normal, int range = 200): base("layer") {
             Target = target;

--- a/Apollo/Devices/LayerFilter.cs
+++ b/Apollo/Devices/LayerFilter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -34,10 +35,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new LayerFilter(Target, Range) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Target, Range };
 
         public LayerFilter(int target = 0, int range = 0): base("layerfilter", "Layer Filter") {
             Target = target;

--- a/Apollo/Devices/Loop.cs
+++ b/Apollo/Devices/Loop.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Rendering;
 using Apollo.Structures;
 using Apollo.Undo;
@@ -80,7 +81,8 @@ namespace Apollo.Devices {
             }
         }
                
-        public override Device Clone() => new Loop(Rate.Clone(), Gate, Repeats, Hold);
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Rate.Clone(), Gate, Repeats, Hold };
         
         public Loop(Time rate = null, double gate = 1, int repeats = 2, bool hold = false): base("loop") {
             Rate = rate?? new Time();

--- a/Apollo/Devices/MacroFilter.cs
+++ b/Apollo/Devices/MacroFilter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Apollo.Core;
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -34,10 +35,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new MacroFilter(Macro, _filter.ToArray()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Macro, _filter.ToArray() };
 
         public bool this[int index] {
             get => _filter[index];

--- a/Apollo/Devices/Move.cs
+++ b/Apollo/Devices/Move.cs
@@ -37,10 +37,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Move(Offset.Clone(), GridMode, Wrap) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Offset.Clone(), GridMode, Wrap };
 
         public Move(Offset offset = null, GridType gridmode = GridType.Full, bool wrap = false): base("move") {
             Offset = offset?? new Offset();

--- a/Apollo/Devices/Multi.cs
+++ b/Apollo/Devices/Multi.cs
@@ -44,10 +44,8 @@ namespace Apollo.Devices {
             base.Reroute();
         }
 
-        public override Device Clone() => new Multi(Preprocess.Clone(), Chains.Select(i => i.Clone()).ToList(), Expanded, Mode) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Preprocess.Clone(purpose), Chains.Select(i => i.Clone(purpose)).ToList(), Expanded, Mode };
 
         void HandleReset() => current = -1;
 

--- a/Apollo/Devices/Output.cs
+++ b/Apollo/Devices/Output.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Apollo.Core;
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -57,10 +58,8 @@ namespace Apollo.Devices {
 
         public Launchpad Launchpad => Program.Project.Tracks[Target].Launchpad;
 
-        public override Device Clone() => new Output(Target) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Target };
 
         public Output(int target = -1): base("output") {
             if (target < 0) target = Track.Get(this).ParentIndex.Value;
@@ -71,6 +70,8 @@ namespace Apollo.Devices {
         }
 
         protected override void Initialized() {
+            if (Purpose != PurposeType.Active) return;
+
             Program.Project.Tracks[_target].ParentIndexChanged += IndexChanged;
             Program.Project.Tracks[_target].Disposing += IndexRemoved;
         }
@@ -83,9 +84,11 @@ namespace Apollo.Devices {
         public override void Dispose() {
             if (Disposed) return;
 
-            if (Program.Project.Tracks.ElementAtOrDefault(_target) is Track track) {
-                track.ParentIndexChanged -= IndexChanged;
-                track.Disposing -= IndexRemoved;
+            if (Purpose == PurposeType.Active) {
+                if (Program.Project.Tracks.ElementAtOrDefault(_target) is Track track) {
+                    track.ParentIndexChanged -= IndexChanged;
+                    track.Disposing -= IndexRemoved;
+                }
             }
 
             base.Dispose();

--- a/Apollo/Devices/Paint.cs
+++ b/Apollo/Devices/Paint.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -20,10 +21,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Paint(Color.Clone()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Color.Clone() };
 
         public Paint(Color color = null): base("paint") => Color = color?? new Color();
 

--- a/Apollo/Devices/Pattern.cs
+++ b/Apollo/Devices/Pattern.cs
@@ -196,10 +196,8 @@ namespace Apollo.Devices {
             }
         }
         
-        public override Device Clone() => new Pattern(Repeats, Gate, Pinch, Bilateral, Frames.Select(i => i.Clone()).ToList(), Mode, Infinite, RootKey, Wrap, Expanded) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Repeats, Gate, Pinch, Bilateral, Frames.Select(i => i.Clone()).ToList(), Mode, Infinite, RootKey, Wrap, Expanded };
 
         int _expanded;
         public int Expanded {
@@ -418,7 +416,7 @@ namespace Apollo.Devices {
             FrameInsertedUndoEntry(BinaryReader reader, int version)
             : base(reader, version) {
                 index = reader.ReadInt32();
-                frame = Decoder.Decode<Frame>(reader, version);
+                frame = Decoder.Decode<Frame>(reader, version, PurposeType.Passive);
             }
             
             public override void Encode(BinaryWriter writer) {
@@ -482,8 +480,8 @@ namespace Apollo.Devices {
         
             protected DurationUndoEntry(BinaryReader reader, int version): base(reader, version) {
                 left = reader.ReadInt32();
-                u = Enumerable.Range(0, reader.ReadInt32()).Select(i => Decoder.Decode<Time>(reader, version)).ToList();
-                r = Decoder.DecodeAnything<I>(reader, version);
+                u = Enumerable.Range(0, reader.ReadInt32()).Select(i => Decoder.Decode<Time>(reader, version, PurposeType.Passive)).ToList();
+                r = Decoder.DecodeAnything<I>(reader, version, PurposeType.Passive);
             }
             
             public override void Encode(BinaryWriter writer) {
@@ -697,7 +695,7 @@ namespace Apollo.Devices {
             }
             
             public ImportUndoEntry(Pattern pattern, string filename, Pattern r)
-            : base($"Pattern File Imported from {filename}", pattern, (Pattern)pattern.Clone(), r) {}
+            : base($"Pattern File Imported from {filename}", pattern, (Pattern)pattern.Clone(PurposeType.Passive), r) {}
             
             ImportUndoEntry(BinaryReader reader, int version)
             : base(reader, version) {}

--- a/Apollo/Devices/Preview.cs
+++ b/Apollo/Devices/Preview.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Rendering;
 using Apollo.Structures;
 
@@ -19,10 +20,8 @@ namespace Apollo.Devices {
             if (Viewer?.SpecificViewer != null) ((PreviewViewer)Viewer.SpecificViewer).Clear();
         }
 
-        public override Device Clone() => new Preview() {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[0];
 
         public Preview(): base("preview") {
             screen = new Screen() { ScreenExit = PreviewExit };

--- a/Apollo/Devices/Refresh.cs
+++ b/Apollo/Devices/Refresh.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Apollo.Core;
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -19,10 +20,8 @@ namespace Apollo.Devices {
             if (Viewer?.SpecificViewer != null) ((RefreshViewer)Viewer.SpecificViewer).SetMacro(index, macro);
         }
         
-        public override Device Clone() => new Refresh(_macros.ToArray()) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { _macros.ToArray() };
 
         public Refresh(bool[] macros = null): base("refresh") {
             if (macros == null || macros.Length != 4) macros = new bool[4];

--- a/Apollo/Devices/Rotate.cs
+++ b/Apollo/Devices/Rotate.cs
@@ -31,10 +31,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Rotate(Mode, Bypass) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Mode, Bypass };
 
         public Rotate(RotateType mode = RotateType.D90, bool bypass = false): base("rotate") {
             Mode = mode;

--- a/Apollo/Devices/Switch.cs
+++ b/Apollo/Devices/Switch.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Apollo.Core;
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -34,10 +35,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Switch(Target, Value) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Target, Value };
 
         public Switch(int target = 1, int value = 1): base("switch") {
             Target = target;

--- a/Apollo/Devices/Tone.cs
+++ b/Apollo/Devices/Tone.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 using Apollo.DeviceViewers;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -65,10 +66,8 @@ namespace Apollo.Devices {
             }
         }
 
-        public override Device Clone() => new Tone(Hue, SaturationHigh, SaturationLow, ValueHigh, ValueLow) {
-            Collapsed = Collapsed,
-            Enabled = Enabled
-        };
+        protected override object[] CloneParameters(PurposeType purpose)
+            => new object[] { Hue, SaturationHigh, SaturationLow, ValueHigh, ValueLow };
 
         public Tone(double hue = 0, double saturation_high = 1, double saturation_low = 0, double value_high = 1, double value_low = 0): base("tone") {
             Hue = hue;

--- a/Apollo/Elements/Chain.cs
+++ b/Apollo/Elements/Chain.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls;
 using Apollo.Binary;
 using Apollo.Devices;
 using Apollo.DeviceViewers;
+using Apollo.Enums;
 using Apollo.Selection;
 using Apollo.Structures;
 using Apollo.Undo;
@@ -31,7 +32,7 @@ namespace Apollo.Elements {
 
         public void IInsert(int index, ISelect item) => Insert(index, (Device)item);
         
-        public ISelect IClone() => (ISelect)Clone();
+        public ISelect IClone(PurposeType purpose) => (ISelect)Clone(purpose);
 
         public ISelectParentViewer IViewer {
             get => Viewer;
@@ -160,7 +161,7 @@ namespace Apollo.Elements {
             }
         }
 
-        public Chain Clone() => new Chain(Devices.Select(i => i.Clone()).ToList(), Name, SecretMultiFilter.ToArray()) {
+        public Chain Clone(PurposeType purpose) => new Chain(Devices.Select(i => i.Clone(purpose)).ToList(), Name, SecretMultiFilter.ToArray()) {
             Enabled = Enabled
         };
 
@@ -223,20 +224,20 @@ namespace Apollo.Elements {
             Device device;
 
             protected override void UndoPath(params Chain[] items) => items[0].Remove(index);
-            protected override void RedoPath(params Chain[] items) => items[0].Insert(index, device.Clone());
+            protected override void RedoPath(params Chain[] items) => items[0].Insert(index, device.Clone(PurposeType.Active));
             
             protected override void OnDispose() => device.Dispose();
             
             public DeviceInsertedUndoEntry(Chain chain, int index, Device device)
             : base($"Device ({device.Name}) Inserted", chain) {
                 this.index = index;
-                this.device = device.Clone();
+                this.device = device.Clone(PurposeType.Passive);
             }
             
             DeviceInsertedUndoEntry(BinaryReader reader, int version)
             : base(reader, version) {
                 index = reader.ReadInt32();
-                device = Decoder.Decode<Device>(reader, version);
+                device = Decoder.Decode<Device>(reader, version, PurposeType.Passive);
             }
             
             public override void Encode(BinaryWriter writer) {

--- a/Apollo/Elements/Device.cs
+++ b/Apollo/Elements/Device.cs
@@ -88,14 +88,15 @@ namespace Apollo.Elements {
                     return;
                 }
 
+                // Purpose is always Active at this point
+
                 if (Program.Project == null) {
                     Program.ProjectLoaded += Initialize;
                     ListeningToProjectLoaded = true;
                     return;
                 }
 
-                if (Track.Get(this) != null)
-                    Initialized();
+                Initialized();
             }
 
             if (ListeningToProjectLoaded) {

--- a/Apollo/Elements/Device.cs
+++ b/Apollo/Elements/Device.cs
@@ -55,9 +55,6 @@ namespace Apollo.Elements {
         protected abstract object[] CloneParameters(PurposeType purpose);
 
         public Device Clone(PurposeType purpose) {
-            if (purpose == PurposeType.Unknown)
-                Program.Log("WARNING: Purpose is unknown while cloning device!");
-
             Device device = Create(this.GetType(), purpose, CloneParameters(purpose));
 
             device.Collapsed = Collapsed;
@@ -67,10 +64,8 @@ namespace Apollo.Elements {
         }
         
         protected Device(string identifier, string name = null) {
-            string s = $"constructing device {identifier}";
-            Program.Log(s);
             if (Purpose == PurposeType.Unknown)
-                throw new Exception($"Purpose is unknown while {s}");
+                throw new Exception($"Purpose is unknown while constructing device {identifier}");
 
             DeviceIdentifier = identifier;
             Name = name?? this.GetType().ToString().Split(".").Last();

--- a/Apollo/Elements/Launchpad.cs
+++ b/Apollo/Elements/Launchpad.cs
@@ -301,7 +301,7 @@ namespace Apollo.Elements {
 
         public Color GetColor(int index) => (PatternWindow == null)
             ? screen.GetColor(index)
-            : PatternWindow.Device.Frames[PatternWindow.Device.Expanded].Screen[index].Clone();
+            : PatternWindow.PatternDevice.Frames[PatternWindow.PatternDevice.Expanded].Screen[index].Clone();
 
         static readonly byte[] DeviceInquiry = new byte[] {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
         static readonly byte[] VersionInquiry = new byte[] {0xF0, 0x00, 0x20, 0x29, 0x00, 0x70, 0xF7};

--- a/Apollo/Elements/Project.cs
+++ b/Apollo/Elements/Project.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 
 using Apollo.Binary;
 using Apollo.Core;
+using Apollo.Enums;
 using Apollo.Selection;
 using Apollo.Undo;
 using Apollo.Windows;
@@ -300,20 +301,20 @@ namespace Apollo.Elements {
             Track track;
 
             protected override void OnUndo() => Program.Project.Remove(index);
-            protected override void OnRedo() => Program.Project.Insert(index, track.Clone());
+            protected override void OnRedo() => Program.Project.Insert(index, track.Clone(PurposeType.Active));
 
             protected override void OnDispose() => track.Dispose();
             
             public TrackInsertedUndoEntry(int index, Track track)
             : base($"Track {index + 1} Inserted") {
                 this.index = index;
-                this.track = track.Clone();
+                this.track = track.Clone(PurposeType.Passive);
             }
             
             TrackInsertedUndoEntry(BinaryReader reader, int version)
             : base(reader, version) {
                 index = reader.ReadInt32();
-                track = Decoder.Decode<Track>(reader, version);
+                track = Decoder.Decode<Track>(reader, version, PurposeType.Passive);
             }
             
             public override void Encode(BinaryWriter writer) {

--- a/Apollo/Elements/Track.cs
+++ b/Apollo/Elements/Track.cs
@@ -2,6 +2,7 @@
 
 using Apollo.Core;
 using Apollo.Devices;
+using Apollo.Enums;
 using Apollo.Selection;
 using Apollo.Structures;
 using Apollo.Rendering;
@@ -22,7 +23,7 @@ namespace Apollo.Elements {
             get => ParentIndex;
         }
         
-        public ISelect IClone() => (ISelect)Clone();
+        public ISelect IClone(PurposeType purpose) => (ISelect)Clone(purpose);
 
         public TrackInfo Info;
         public TrackWindow Window;
@@ -128,7 +129,7 @@ namespace Apollo.Elements {
             }
         }
 
-        public Track Clone() => new Track(Chain.Clone(), Launchpad, Name) {
+        public Track Clone(PurposeType purpose) => new Track(Chain.Clone(purpose), Launchpad, Name) {
             Enabled = Enabled
         };
 

--- a/Apollo/Enums/Enums.cs
+++ b/Apollo/Enums/Enums.cs
@@ -79,6 +79,10 @@ namespace Apollo.Enums {
         Linear, Smooth, Sharp, Fast, Slow, Hold, Release
     }
 
+    public enum PurposeType {
+        Unknown, Active, Passive, Unrelated
+    }
+
     public static class EnumExtensions {
         public static bool HasNovationLED(this LaunchpadModels model)
             => model == LaunchpadModels.X || model == LaunchpadModels.ProMK3;

--- a/Apollo/Helpers/Copyable.cs
+++ b/Apollo/Helpers/Copyable.cs
@@ -9,6 +9,7 @@ using Avalonia;
 using Avalonia.Controls;
 
 using Apollo.Binary;
+using Apollo.Enums;
 using Apollo.Selection;
 using Apollo.Windows;
 
@@ -138,7 +139,7 @@ namespace Apollo.Helpers {
 
             try {
                 using (MemoryStream ms = new MemoryStream(FromCompressedBase64(b64)))
-                    return await Decoder.Decode<Copyable>(ms);
+                    return await Decoder.Decode<Copyable>(ms, PurposeType.Passive);
             } catch (Exception) {
                 return null;
             }
@@ -152,7 +153,7 @@ namespace Apollo.Helpers {
                     Copyable copyable;
 
                     using (FileStream file = File.Open(path, FileMode.Open, FileAccess.Read))
-                        copyable = await Decoder.Decode<Copyable>(file);
+                        copyable = await Decoder.Decode<Copyable>(file, PurposeType.Passive);
 
                     if (!ensure.IsAssignableFrom(copyable.Type))
                         throw new InvalidDataException();

--- a/Apollo/Selection/DragDropManager.cs
+++ b/Apollo/Selection/DragDropManager.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Apollo.Core;
 using Apollo.Devices;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Structures;
 using Apollo.Undo;
 
@@ -33,7 +34,7 @@ namespace Apollo.Selection {
             for (int i = 0; i < source.Count; i++) {
                 if (!copy) source[i].IParent.Remove(source[i].IParentIndex.Value, false);
 
-                source[i] = copy? source[i].IClone() : source[i];
+                source[i] = copy? source[i].IClone(PurposeType.Active) : source[i];
 
                 if (source[i] is Pattern pattern)
                     pattern.Window?.Close();

--- a/Apollo/Selection/Interfaces.cs
+++ b/Apollo/Selection/Interfaces.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
 
+using Apollo.Enums;
+
 namespace Apollo.Selection {
     public interface ISelect {
         ISelectViewer IInfo { get; }
@@ -11,7 +13,7 @@ namespace Apollo.Selection {
         ISelectParent IParent { get; }
         int? IParentIndex { get; }
 
-        ISelect IClone();
+        ISelect IClone(PurposeType purpose);
         
         void Dispose();
     }

--- a/Apollo/Structures/Frame.cs
+++ b/Apollo/Structures/Frame.cs
@@ -2,6 +2,7 @@ using System.Linq;
 
 using Apollo.Components;
 using Apollo.Devices;
+using Apollo.Enums;
 using Apollo.Selection;
 
 namespace Apollo.Structures {
@@ -18,7 +19,7 @@ namespace Apollo.Structures {
             get => ParentIndex;
         }
         
-        public ISelect IClone() => (ISelect)Clone();
+        public ISelect IClone(PurposeType purpose) => (ISelect)Clone();
         
         Color[] _screen;
         public Color[] Screen {

--- a/Apollo/Undo/UndoEntry.cs
+++ b/Apollo/Undo/UndoEntry.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Avalonia.Controls;
 
 using Apollo.Binary;
+using Apollo.Enums;
 using Apollo.Selection;
 
 namespace Apollo.Undo {
@@ -62,7 +63,7 @@ namespace Apollo.Undo {
                 UndoBinary.DecodeID(reader),
                 BindingFlags.NonPublic | BindingFlags.Instance,
                 null,
-                new object[] { reader, version },
+                new object[] { reader, version }, // All UndoEntries always assume PurposeType.Passive!
                 null
             );
     }
@@ -85,8 +86,8 @@ namespace Apollo.Undo {
 
         protected SimpleUndoEntry(BinaryReader reader, int version)
         : base(reader, version) {
-            u = Decoder.DecodeAnything<I>(reader, version);
-            r = Decoder.DecodeAnything<I>(reader, version);
+            u = Decoder.DecodeAnything<I>(reader, version, PurposeType.Passive);
+            r = Decoder.DecodeAnything<I>(reader, version, PurposeType.Passive);
         }
 
         public override void Encode(BinaryWriter writer) {
@@ -175,8 +176,8 @@ namespace Apollo.Undo {
 
         protected SimplePathUndoEntry(BinaryReader reader, int version)
         : base(reader, version) {
-            u = Decoder.DecodeAnything<I>(reader, version);
-            r = Decoder.DecodeAnything<I>(reader, version);
+            u = Decoder.DecodeAnything<I>(reader, version, PurposeType.Passive);
+            r = Decoder.DecodeAnything<I>(reader, version, PurposeType.Passive);
         }
 
         public override void Encode(BinaryWriter writer) {

--- a/Apollo/Viewers/ChainViewer.cs
+++ b/Apollo/Viewers/ChainViewer.cs
@@ -10,6 +10,7 @@ using Avalonia.Media;
 
 using Apollo.Components;
 using Apollo.Core;
+using Apollo.Enums;
 using Apollo.Elements;
 using Apollo.Selection;
 
@@ -93,7 +94,7 @@ namespace Apollo.Viewers {
 
         public void Expand(int? index) {}
 
-        void Device_Insert(int index, Type device) => Device_Insert(index, Device.Create(device, _chain));
+        void Device_Insert(int index, Type device) => Device_Insert(index, Device.Create(device, PurposeType.Passive));
         void Device_InsertStart(Type device) => Device_Insert(0, device);
 
         void Device_Insert(int index, Device device) {

--- a/Apollo/Windows/PatternWindow.cs
+++ b/Apollo/Windows/PatternWindow.cs
@@ -86,7 +86,7 @@ namespace Apollo.Windows {
         Pattern _pattern;
         Track _track;
 
-        public Pattern Device { get => _pattern; }
+        public Pattern PatternDevice { get => _pattern; }
         
         Launchpad _launchpad;
         Launchpad Launchpad {
@@ -1099,7 +1099,18 @@ namespace Apollo.Windows {
                     Program.Project.Undo.AddAndExecute(new Pattern.ImportUndoEntry(
                         _pattern,
                         Path.GetFileNameWithoutExtension(filepath),
-                        new Pattern(frames: frames.Select(i => i.Clone()).ToList())
+                        Device.Create<Pattern>(PurposeType.Passive, new object[] {
+                            Type.Missing,
+                            Type.Missing,
+                            Type.Missing,
+                            Type.Missing,
+                            frames.Select(i => i.Clone()).ToList(),
+                            Type.Missing,
+                            Type.Missing,
+                            Type.Missing,
+                            Type.Missing,
+                            Type.Missing,
+                        })
                     ));
                 }
             }

--- a/Apollo/Windows/PreferencesWindow.cs
+++ b/Apollo/Windows/PreferencesWindow.cs
@@ -91,9 +91,11 @@ namespace Apollo.Windows {
         DispatcherTimer Timer;
         LaunchpadGrid Preview;
 
-        Fade fade = new Fade(
+        Fade fade = Device.Create<Fade>(PurposeType.Unrelated, new object[] {
             new Time(false),
-            colors: new List<Color>() {
+            Type.Missing,
+            Type.Missing,
+            new List<Color>() {
                 new Color(1, 0, 0),
                 new Color(63, 0, 0),
                 new Color(63, 63, 0),
@@ -104,10 +106,10 @@ namespace Apollo.Windows {
                 new Color(63, 0, 0),
                 new Color(1, 0, 0)
             },
-            positions: new List<double>() {
+            new List<double>() {
                 0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1
             },
-            types: new List<FadeType>{
+            new List<FadeType>{
                 FadeType.Linear,
                 FadeType.Linear,
                 FadeType.Linear,
@@ -117,8 +119,9 @@ namespace Apollo.Windows {
                 FadeType.Linear,
                 FadeType.Linear,
                 FadeType.Linear
-            }
-        );
+            },
+            Type.Missing
+        });
 
         void UpdateTopmost(bool value) => AlwaysOnTop.IsChecked = Topmost = value;
 

--- a/Apollo/Windows/SplashWindow.cs
+++ b/Apollo/Windows/SplashWindow.cs
@@ -20,6 +20,7 @@ using Apollo.Components;
 using Apollo.Core;
 using Apollo.Devices;
 using Apollo.Elements;
+using Apollo.Enums;
 using Apollo.Helpers;
 using Apollo.Viewers;
 
@@ -206,7 +207,7 @@ namespace Apollo.Windows {
             try {
                 try {
                     using (FileStream file = File.Open(path, FileMode.Open, FileAccess.Read))
-                        loaded = await Decoder.Decode<Project>(file);
+                        loaded = await Decoder.Decode<Project>(file, PurposeType.Active);
 
                     if (!recovery) {
                         loaded.FilePath = path;
@@ -219,7 +220,7 @@ namespace Apollo.Windows {
 
                 } catch (InvalidDataException) {
                     using (FileStream file = File.Open(path, FileMode.Open, FileAccess.Read))
-                        imported = await Decoder.Decode<Copyable>(file);
+                        imported = await Decoder.Decode<Copyable>(file, PurposeType.Active);
 
                     Program.Project?.Dispose();
                     Program.Project = new Project(
@@ -227,7 +228,13 @@ namespace Apollo.Windows {
                             ? imported.Contents.Cast<Track>().ToList()
                             : new List<Track>() {
                                 new Track(new Chain((imported.Type == typeof(Chain))
-                                    ? new List<Device>() { new Group(imported.Contents.Cast<Chain>().ToList()) }
+                                    ? new List<Device>() {
+                                        Device.Create<Group>(PurposeType.Active, new object[] {
+                                            imported.Contents.Cast<Chain>().ToList(),
+                                            Type.Missing,
+                                            Type.Missing
+                                        })
+                                    }
                                     : imported.Contents.Cast<Device>().ToList()
                                 ))
                             }


### PR DESCRIPTION
Newly added Purpose field is required to be set BEFORE any device initializes:

- Active in the chain
- Passive in other places like Undo History etc.
- Unrelated being active but outside the chain (think the Fade in Preferences)
- Unknown is the default value which should throw an Exception to generate a crash log, in case I missed a spot

This is done using reflection, as the constructor needs to already know what purpose the device is being created for but adding a new parameter to the constructor is not desirable.

Fixes #390 and should also fix all Output bugs.
Also happens to fix #455 as code that caused that issue had to be refactored for this anyways.

Ready to merge after some more bugtesting :)