### PR TITLE
MIDI Fighter 64 support

### DIFF
--- a/Apollo/Components/FrameThumbnail.cs
+++ b/Apollo/Components/FrameThumbnail.cs
@@ -70,6 +70,7 @@ namespace Apollo.Components {
                                 break;
                             
                             case LaunchpadModels.Matrix:
+                            case LaunchpadModels.MF64:
                                 if (x == 0 || y == 0 || x == 9 || y == 9) continue;
                                 break;
                         }

--- a/Apollo/Components/LaunchpadButton.cs
+++ b/Apollo/Components/LaunchpadButton.cs
@@ -26,20 +26,25 @@ namespace Apollo.Components {
             Canvas.Classes.Add(name);
             Path.Classes.Add(name);
 
-            if (name == "corner")
-                Path.Data = (StreamGeometry)Application.Current.Styles.FindResource($"LPGrid_{Index}CornerGeometry");
+            if (name.StartsWith("corner"))
+                Path.Classes.Add($"corner{Index}");
         }
 
         public bool Empty => Canvas.Classes.Contains("empty");
 
         bool IsPhantom() {
-            if (Preferences.LaunchpadModel.HasNovationLED() && Index == 9) return false;
+            if (Preferences.LaunchpadModel == LaunchpadModels.MF64)
+                return true;
+
+            if (Preferences.LaunchpadModel.HasNovationLED() && Index == 9)
+                return false;
 
             if (Preferences.LaunchpadStyle == LaunchpadStyles.Stock) {
                 int x = Index % 10;
                 int y = Index / 10;
 
-                if (x == 0 || x == 9 || y == 0 || y == 9) return true;
+                if (x == 0 || x == 9 || y == 0 || y == 9)
+                    return true;
             }
 
             return Preferences.LaunchpadStyle == LaunchpadStyles.Phantom;
@@ -54,7 +59,7 @@ namespace Apollo.Components {
 
             Canvas.Classes.Clear();
             Path.Classes.Clear();
-
+            
             switch (Preferences.LaunchpadModel) {
                 case LaunchpadModels.MK2:
                     if (x == 0 || y == 9 || Index == 9) AddClass("empty");
@@ -119,16 +124,28 @@ namespace Apollo.Components {
                         else AddClass("square");
                     }
                     break;
+                
+                case LaunchpadModels.MF64:
+                    if (x == 0 || x == 9 || y == 0 || y == 9) AddClass("empty");
+                    else {
+                        ret++;
+                        AddClass("arcade");
+                    }
+                    break;
             }
 
             return ret;
         }
 
         public void UpdateStyle()
-            => Path.Fill = IsPhantom()? SolidColorBrush.Parse("Transparent") : Path.Stroke;
+            => Path.Fill = IsPhantom()
+                ? (SolidColorBrush)Application.Current.Styles.FindResource("ThemePhantomBrush")
+                : Path.Stroke;
 
         public void SetColor(SolidColorBrush color)
-            => Path.Stroke = IsPhantom()? color : Path.Fill = color;
+            => Path.Stroke = IsPhantom()
+                ? color
+                : Path.Fill = color;
 
         public LaunchpadButton() => throw new InvalidOperationException();
 

--- a/Apollo/Components/LaunchpadButton.xaml
+++ b/Apollo/Components/LaunchpadButton.xaml
@@ -48,6 +48,33 @@
       <Setter Property="Stroke" Value="{DynamicResource ThemeForegroundLowBrush}" />
     </Style>
 
+    <Style Selector="Path.corner44">
+      <Setter Property="Data" Value="{DynamicResource LPGrid_44CornerGeometry}" />
+    </Style>
+
+    <Style Selector="Path.corner45">
+      <Setter Property="Data" Value="{DynamicResource LPGrid_45CornerGeometry}" />
+    </Style>
+
+    <Style Selector="Path.corner54">
+      <Setter Property="Data" Value="{DynamicResource LPGrid_54CornerGeometry}" />
+    </Style>
+
+    <Style Selector="Path.corner55">
+      <Setter Property="Data" Value="{DynamicResource LPGrid_55CornerGeometry}" />
+    </Style>
+
+    <Style Selector="Canvas.arcade">
+      <Setter Property="Width" Value="{DynamicResource LPGrid_PadSize}" />
+      <Setter Property="Height" Value="{DynamicResource LPGrid_PadSize}" />
+    </Style>
+    <Style Selector="Path.arcade">
+      <Setter Property="Fill" Value="Transparent" />
+      <Setter Property="StrokeThickness" Value="{DynamicResource LPGrid_ArcadePadThickness}" />
+      <Setter Property="Stroke" Value="{DynamicResource ThemeForegroundLowBrush}" />
+      <Setter Property="Data" Value="{DynamicResource LPGrid_ArcadeGeometry}" />
+    </Style>
+
     <Style Selector="Canvas.hidden">
       <Setter Property="Width" Value="{DynamicResource LPGrid_HiddenSize}" />
       <Setter Property="Height" Value="{DynamicResource LPGrid_HiddenSize}" />

--- a/Apollo/Components/LaunchpadGrid.cs
+++ b/Apollo/Components/LaunchpadGrid.cs
@@ -70,6 +70,18 @@ namespace Apollo.Components {
         void Update_LaunchpadModel() {
             Grid?.Children.Clear();
 
+            bool isMF64 = Preferences.LaunchpadModel == LaunchpadModels.MF64;
+
+            Back.CornerRadius = (CornerRadius)Application.Current.Styles.FindResource(
+                isMF64? "LPGrid_MF64CornerRadius" : "LPGrid_CornerRadius"
+            );
+            Back.BorderThickness = (Thickness)Application.Current.Styles.FindResource(
+                isMF64? "LPGrid_MF64PadMargin" : "LPGrid_PadMargin"
+            );
+            View.Margin = (Thickness)Application.Current.Styles.FindResource(
+                isMF64? "LPGrid_MF64TopMargin" : "LPGrid_TopMargin"
+            );
+
             int buttons = Preferences.LaunchpadModel.GridSize();
             int xoffset = Preferences.LaunchpadModel.GridOffsetX();
             int yoffset = Preferences.LaunchpadModel.GridOffsetY();

--- a/Apollo/Components/LaunchpadGrid.xaml
+++ b/Apollo/Components/LaunchpadGrid.xaml
@@ -12,9 +12,9 @@
                             PointerMoved="MouseMove" PointerReleased="MouseUp">
       
       <Grid>
-        <Border BorderBrush="{DynamicResource ThemeBorderHighBrush}" Background="{DynamicResource ThemeControlLowBrush}" BorderThickness="{DynamicResource LPGrid_PadMargin}" CornerRadius="{DynamicResource LPGrid_CornerRadius}" x:Name="Back" />
+        <Border BorderBrush="{DynamicResource ThemeBorderMidBrush}" Background="{DynamicResource ThemeControlLowBrush}" x:Name="Back" />
 
-        <Border Margin="{DynamicResource LPGrid_TopMargin}" x:Name="View" />
+        <Border x:Name="View" />
 
         <Rectangle Margin="{DynamicResource LPGrid_ModeMargin}" Cursor="Hand" HorizontalAlignment="Center" VerticalAlignment="Bottom" Fill="{DynamicResource ModeBrush}" Width="{DynamicResource LPGrid_ModeWidth}" Height="{DynamicResource LPGrid_ModeHeight}" x:Name="ModeLight"
                    PointerPressed="MouseDown" />

--- a/Apollo/Elements/Launchpads/Launchpad.cs
+++ b/Apollo/Elements/Launchpads/Launchpad.cs
@@ -216,6 +216,17 @@ namespace Apollo.Elements.Launchpads {
             )
         );
 
+        public static PortWarning MF64FirmwareUnsupported { get; private set; } = new PortWarning(
+            "One or more connected Midi Fighter 64s are running the official\n" + 
+            "firmware which is not compatible with Apollo Studio.\n\n" +
+            "Update these to the latest version of the custom firmware using the\n" +
+            "MIDI Fighter Utility to avoid any potential issues with Apollo Studio.",
+            new PortWarning.Option(
+                "Custom Firmware Guide",
+                "https://github.com/mat1jaczyyy/mf64-performance-cfw/blob/master/README.md#installation"
+            )
+        );
+
         public static void DisplayWarnings(Window sender) {
             Dispatcher.UIThread.Post(() => {
                 if (MK2FirmwareOld.DisplayWarning(sender)) return;
@@ -233,6 +244,7 @@ namespace Apollo.Elements.Launchpads {
                 if (MatrixFEFirmwareUnsupported.DisplayWarning(sender)) return;
                 if (MatrixFirmwareUnsupported.DisplayWarning(sender)) return;
                 if (MatrixProFirmwareUnsupported.DisplayWarning(sender)) return;
+                if (MF64FirmwareUnsupported.DisplayWarning(sender)) return;
             }, DispatcherPriority.MinValue);
         }
 
@@ -271,7 +283,8 @@ namespace Apollo.Elements.Launchpads {
             {LaunchpadType.ProMK3, SysExStart.Concat(NovationHeader).Concat(new byte[] {0x0E, 0x03}).ToArray()},
             {LaunchpadType.MatrixFE, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5E}).ToArray()},
             {LaunchpadType.Matrix, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5E}).ToArray()},
-            {LaunchpadType.MatrixPro, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5E}).ToArray()}
+            {LaunchpadType.MatrixPro, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5E}).ToArray()},
+            {LaunchpadType.MF64, SysExStart.Concat(new byte[] {0x6F}).ToArray()}
         };
 
         static byte[] ProGridMessage = SysExStart.Concat(NovationHeader).Concat(new byte[] {0x10, 0x0F, 0x00}).ToArray();
@@ -287,7 +300,8 @@ namespace Apollo.Elements.Launchpads {
             ).ToArray()},
             {LaunchpadType.MatrixFE, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5F, 0x00, 0x00, 0x40, 0x00}).ToArray()},
             {LaunchpadType.Matrix, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5F, 0x00, 0x00, 0x40, 0x00}).ToArray()},
-            {LaunchpadType.MatrixPro, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5F, 0x00, 0x00, 0x40, 0x00}).ToArray()}
+            {LaunchpadType.MatrixPro, SysExStart.Concat(MatrixHeader).Concat(new byte[] {0x5F, 0x00, 0x00, 0x40, 0x00}).ToArray()},
+            {LaunchpadType.MF64, SysExStart.Concat(new byte[] {0x6E}).ToArray()}
         };
 
         static Dictionary<byte, LaunchpadType> MatrixDevices = new() {
@@ -498,6 +512,23 @@ namespace Apollo.Elements.Launchpads {
 
                 SupportsCompression = true;
                 return type;
+            
+            // Manufacturer = DJTechTools
+            } else if (response.Data[5] == 0x00 && response.Data[6] == 0x01 && response.Data[7] == 0x79 ) {
+                ushort family = (ushort)(response.Data[9] << 8 | response.Data[8]);
+                ushort model = (ushort)(response.Data[11] << 8 | response.Data[10]);
+                uint version = (ushort)(response.Data[12] << 24 | response.Data[13] << 16 | response.Data[14] << 8 | response.Data[15]);
+
+                if (family == 0x0006 && model == 0x0001) { // Midi Fighter 64
+                    if (response.Data[12] != 0x30) { // Not CFW
+                        MF64FirmwareUnsupported.Set();
+                        return LaunchpadType.Unknown;
+                    }
+
+                    return LaunchpadType.MF64;
+                }
+
+                return LaunchpadType.Unknown;
             }
 
             return LaunchpadType.Unknown;
@@ -577,18 +608,16 @@ namespace Apollo.Elements.Launchpads {
             List<RawUpdate> output = n.SelectMany(i => {              
                 IEnumerable<RawUpdate> ret = Enumerable.Empty<RawUpdate>();
 
-                int offset = 0;
-
                 switch (Type) {
                     case LaunchpadType.MK2:
                         if (i.Index % 10 == 0 || i.Index < 11 || i.Index == 99 || i.Index == 100) return ret;
-                        if (91 <= i.Index && i.Index <= 98) offset = 13;
+                        if (91 <= i.Index && i.Index <= 98) i.Offset(13);
                         break;
                     
                     case LaunchpadType.Pro:
                     case LaunchpadType.CFW:
                         if (i.Index == 0 || i.Index == 9 || i.Index == 90 || i.Index == 99) return ret;
-                        else if (i.Index == 100) offset = -1;
+                        else if (i.Index == 100) i.Offset(-1);
                         break;
 
                     case LaunchpadType.X:
@@ -609,9 +638,13 @@ namespace Apollo.Elements.Launchpads {
                     case LaunchpadType.MatrixPro:
                         if (i.Index == 0 || i.Index == 9 || i.Index == 90 || i.Index == 99 || i.Index == 100) return ret;
                         break;
+
+                    case LaunchpadType.MF64:
+                        if (i.Index % 10 == 0 || i.Index % 10 == 9 || i.Index < 11 || i.Index > 88 || i.Index == 100) return ret;
+                        i.Index = Converter.XYtoMF64(i.Index);
+                        break;
                 }
                 
-                i.Offset(offset);
                 return ret.Append(i).ToArray();
 
             }).ToList();
@@ -654,6 +687,7 @@ namespace Apollo.Elements.Launchpads {
             {LaunchpadType.MatrixFE, new HashSet<byte>() {100, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 19, 20, 29, 30, 39, 40, 49, 50, 59, 60, 69, 70, 79, 80, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99}},
             {LaunchpadType.Matrix, new HashSet<byte>() {100, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 19, 20, 29, 30, 39, 40, 49, 50, 59, 60, 69, 70, 79, 80, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99}},
             {LaunchpadType.MatrixPro, new HashSet<byte>() {100, 0, 9, 90, 99}},
+            {LaunchpadType.MF64, new HashSet<byte>() {100, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 19, 20, 29, 30, 39, 40, 49, 50, 59, 60, 69, 70, 79, 80, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99}},
         };
 
         bool Optimize(List<RawUpdate> updates, out IEnumerable<byte> ret) {

--- a/Apollo/Elements/Launchpads/Launchpad.cs
+++ b/Apollo/Elements/Launchpads/Launchpad.cs
@@ -220,10 +220,10 @@ namespace Apollo.Elements.Launchpads {
             "One or more connected Midi Fighter 64s are running the official\n" + 
             "firmware which is not compatible with Apollo Studio.\n\n" +
             "Update these to the latest version of the custom firmware using the\n" +
-            "MIDI Fighter Utility to avoid any potential issues with Apollo Studio.",
+            "Launchpad Firmware Utility to avoid any potential issues with Apollo Studio.",
             new PortWarning.Option(
-                "Custom Firmware Guide",
-                "https://github.com/mat1jaczyyy/mf64-performance-cfw/blob/master/README.md#installation"
+                "Launch Firmware Utility",
+                "https://fw.mat1jaczyyy.com"
             )
         );
 

--- a/Apollo/Enums/Enums.cs
+++ b/Apollo/Enums/Enums.cs
@@ -1,3 +1,5 @@
+using Apollo.Elements.Launchpads;
+
 namespace Apollo.Enums {
     public enum Palettes {
         Monochrome, NovationPalette, CustomPalette
@@ -12,7 +14,7 @@ namespace Apollo.Enums {
     }
 
     public enum LaunchpadModels {
-        MK2, Pro, X, ProMK3, All, Matrix
+        MK2, Pro, X, ProMK3, All, Matrix, MF64
     }
 
     public enum LaunchpadStyles {
@@ -60,7 +62,7 @@ namespace Apollo.Enums {
     }
 
     public enum LaunchpadType {
-        MK2, Pro, CFW, X, MiniMK3, ProMK3, MatrixFE, Matrix, MatrixPro, Unknown
+        MK2, Pro, CFW, X, MiniMK3, ProMK3, MatrixFE, Matrix, MatrixPro, MF64, Unknown
     }
 
     public enum InputType {
@@ -91,7 +93,7 @@ namespace Apollo.Enums {
             if (model == LaunchpadModels.Pro || model == LaunchpadModels.ProMK3 || model == LaunchpadModels.All)
                 return 10;
             
-            if (model == LaunchpadModels.Matrix)
+            if (model == LaunchpadModels.Matrix || model == LaunchpadModels.MF64)
                 return 8;
                 
             return 9;

--- a/Apollo/Helpers/Converter.cs
+++ b/Apollo/Helpers/Converter.cs
@@ -6,5 +6,6 @@ namespace Apollo.Helpers {
 
         public static byte DRtoXY(int dr) => _DRtoXY[dr];
         public static byte XYtoDR(int xy) => (byte)Array.IndexOf(_DRtoXY, (byte)xy);
+        public static byte XYtoMF64(int xy) => (byte)(XYtoDR(xy) - 36);
     }
 }

--- a/Apollo/Themes/Common.xaml
+++ b/Apollo/Themes/Common.xaml
@@ -39,14 +39,18 @@
     <sys:Double x:Key="LPGrid_NovationSize">33</sys:Double>
     <sys:Double x:Key="LPGrid_HiddenSize">21</sys:Double>
     <sys:Double x:Key="LPGrid_PadThickness">3</sys:Double>
+    <sys:Double x:Key="LPGrid_ArcadePadThickness">7.5</sys:Double>
     <sys:Double x:Key="LPGrid_PadCut1">9</sys:Double>
     <sys:Double x:Key="LPGrid_PadCut2">36</sys:Double>
     <sys:Double x:Key="LPGrid_ModeWidth">12</sys:Double>
     <sys:Double x:Key="LPGrid_ModeHeight">6</sys:Double>
     <CornerRadius x:Key="LPGrid_CornerRadius">3</CornerRadius>
     <Thickness x:Key="LPGrid_TopMargin">21</Thickness>
-    <sys:Double x:Key="LPGrid_PadSpacing">3</sys:Double>
     <Thickness x:Key="LPGrid_PadMargin">3</Thickness>
+    <CornerRadius x:Key="LPGrid_MF64CornerRadius">27</CornerRadius>
+    <Thickness x:Key="LPGrid_MF64TopMargin">16</Thickness>
+    <Thickness x:Key="LPGrid_MF64PadMargin">5</Thickness>
+    <sys:Double x:Key="LPGrid_PadSpacing">3</sys:Double>
 
     <media:StreamGeometry x:Key="LPGrid_SquareGeometry" />
     <media:StreamGeometry x:Key="LPGrid_SplitGeometry" />

--- a/Apollo/Themes/Dark.xaml
+++ b/Apollo/Themes/Dark.xaml
@@ -26,6 +26,7 @@
     <Color x:Key="ThemeButtonOverColor">#FF787878</Color>
     <Color x:Key="ThemeButtonEnabledColor">#FF505050</Color>
     <Color x:Key="ThemeButtonDisabledColor">#FF242424</Color>
+    <Color x:Key="ThemePhantomColor">#FF0A0A0A</Color>
 
     <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{DynamicResource ThemeBackgroundColor}"></SolidColorBrush>
     <SolidColorBrush x:Key="ThemeSplashBrush" Color="{DynamicResource ThemeSplashColor}"></SolidColorBrush>
@@ -47,5 +48,6 @@
     <SolidColorBrush x:Key="ThemeButtonOverBrush" Color="{DynamicResource ThemeButtonOverColor}"></SolidColorBrush>
     <SolidColorBrush x:Key="ThemeButtonEnabledBrush" Color="{DynamicResource ThemeButtonEnabledColor}"></SolidColorBrush>
     <SolidColorBrush x:Key="ThemeButtonDisabledBrush" Color="{DynamicResource ThemeButtonDisabledColor}"></SolidColorBrush>
+    <SolidColorBrush x:Key="ThemePhantomBrush" Color="{DynamicResource ThemePhantomColor}"></SolidColorBrush>
   </Style.Resources>
 </Style>

--- a/Apollo/Themes/Light.xaml
+++ b/Apollo/Themes/Light.xaml
@@ -26,6 +26,7 @@
     <Color x:Key="ThemeButtonOverColor">#FF303030</Color>
     <Color x:Key="ThemeButtonEnabledColor">#FF585858</Color>
     <Color x:Key="ThemeButtonDisabledColor">#FF727272</Color>
+    <Color x:Key="ThemePhantomColor">#FFB3B3B3</Color>
 
     <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{DynamicResource ThemeBackgroundColor}"></SolidColorBrush>
     <SolidColorBrush x:Key="ThemeSplashBrush" Color="{DynamicResource ThemeSplashColor}"></SolidColorBrush>
@@ -47,5 +48,6 @@
     <SolidColorBrush x:Key="ThemeButtonOverBrush" Color="{DynamicResource ThemeButtonOverColor}"></SolidColorBrush>
     <SolidColorBrush x:Key="ThemeButtonEnabledBrush" Color="{DynamicResource ThemeButtonEnabledColor}"></SolidColorBrush>
     <SolidColorBrush x:Key="ThemeButtonDisabledBrush" Color="{DynamicResource ThemeButtonDisabledColor}"></SolidColorBrush>
+    <SolidColorBrush x:Key="ThemePhantomBrush" Color="{DynamicResource ThemePhantomColor}"></SolidColorBrush>
   </Style.Resources>
 </Style>

--- a/Apollo/Themes/Themes.cs
+++ b/Apollo/Themes/Themes.cs
@@ -17,6 +17,7 @@ namespace Apollo.Themes {
         void SetResource(string name, Geometry data) => this.Resources[$"LPGrid_{name}"] = data;
 
         double halfThickness => GetResource("PadThickness") / 2;
+        double arcadeHalfThickness => GetResource("ArcadePadThickness") / 2;
 
         Geometry CreateCornerGeometry(string format) => Geometry.Parse(String.Format(format,
             (GetResource("PadSize") - halfThickness).ToString(),
@@ -37,7 +38,7 @@ namespace Apollo.Themes {
                 (GetResource("PadSize") - halfThickness).ToString(),
                 (GetResource("PadSize") / 2 - halfThickness - GetResource("PadSpacing")).ToString(),
                 (GetResource("PadSize") / 2 + halfThickness + GetResource("PadSpacing")).ToString(),
-                (halfThickness).ToString()
+                halfThickness.ToString()
             )));
 
             SetResource("CircleGeometry", Geometry.Parse(String.Format("M {0},{1} A {2},{2} 180 1 1 {0},{3} A {2},{2} 180 1 1 {0},{1} Z",
@@ -49,7 +50,7 @@ namespace Apollo.Themes {
 
             SetResource("NovationGeometry", Geometry.Parse(String.Format(
                 "F1 M {0},0 L {1},0 C {2},0 0,{2} 0,{1} L 0,{0} C 0,{3} {2},{4} {1},{4} L {0},{4} C {3},{4} {4},{3} {4},{0} L {4},{1} C {4},{2} {3},0 {0},0 Z M {5},{6} L {7},{8} {9},{10} {11},{12} Z M {13},{14} C {15},{16} {17},{18} {19},{20} L {21},{22} {23},{24} {25},{11} {26},{27} C {28},{29} {15},{30} {13},{31} {13},{6} {32},{33} {13},{14} Z",
-                NovationCoordinates.Select(i => (i * (GetResource("NovationSize"))).ToString()).ToArray()
+                NovationCoordinates.Select(i => (i * GetResource("NovationSize")).ToString()).ToArray()
             )));
 
             SetResource("HiddenGeometry", Geometry.Parse(String.Format("M {1},{1} L {1},{0} {0},{0} {0},{1} Z",
@@ -61,6 +62,13 @@ namespace Apollo.Themes {
             SetResource("45CornerGeometry", CreateCornerGeometry("M {3},{3} L {3},{2} {1},{0} {0},{0} {0},{3} Z"));
             SetResource("54CornerGeometry", CreateCornerGeometry("M {3},{3} L {3},{0} {0},{0} {0},{1} {2},{3} Z"));
             SetResource("55CornerGeometry", CreateCornerGeometry("M {3},{1} L {3},{0} {0},{0} {0},{3} {1},{3} Z"));
+
+            SetResource("ArcadeGeometry", Geometry.Parse(String.Format("M {0},{1} A {2},{2} 180 1 1 {0},{3} A {2},{2} 180 1 1 {0},{1} Z",
+                (GetResource("PadSize") / 2).ToString(),
+                arcadeHalfThickness.ToString(),
+                (GetResource("PadSize") / 2 - arcadeHalfThickness).ToString(),
+                (GetResource("PadSize") - arcadeHalfThickness).ToString()
+            )));
         }
     }
 

--- a/Apollo/Windows/PreferencesWindow.xaml
+++ b/Apollo/Windows/PreferencesWindow.xaml
@@ -109,6 +109,7 @@
                     <ComboBoxItem>Pro MK3</ComboBoxItem>
                     <ComboBoxItem>All</ComboBoxItem>
                     <ComboBoxItem>Matrix</ComboBoxItem>
+                    <ComboBoxItem>MF64</ComboBoxItem>
                   </ComboBox>
                 </StackPanel>
 


### PR DESCRIPTION
Support for MIDI Fighter 64 requires the use of [custom firmware](https://github.com/mat1jaczyyy/mf64-performance-cfw). Otherwise, the implementation is mostly standard.

Comes with slight theming changes regarding the On-screen Launchpad UI element for existing devices.

Closes #237.