### PR TITLE
Fix crash on launchpad unplug on modern Windows

### DIFF
--- a/Apollo/Elements/Launchpads/Launchpad.cs
+++ b/Apollo/Elements/Launchpads/Launchpad.cs
@@ -981,11 +981,11 @@ namespace Apollo.Elements.Launchpads {
 
         public virtual void Disconnect(bool actuallyClose = true) {
             if (actuallyClose) {
-                if (Input.IsOpen) Input.Close();
-                Input.Dispose();
-
-                if (Output.IsOpen) Output.Close();
-                Output.Dispose();
+                // Device is already physically gone here (MIDI.Disconnect only
+                // reaches once no matching port remains), and closing a vanished
+                // WinMM device crashes newer Windows. Drop it without closing
+                Input.Abandon();
+                Output.Abandon();
             }
 
             Dispatcher.UIThread.InvokeAsync(() => Window?.Close());

--- a/Apollo/RtMidi/Devices/MidiDevice.cs
+++ b/Apollo/RtMidi/Devices/MidiDevice.cs
@@ -9,6 +9,7 @@ namespace Apollo.RtMidi.Devices {
 
         bool Open();
         void Close();
+        void Abandon();
     }
 
     public abstract class MidiDevice: IMidiDevice {
@@ -24,7 +25,19 @@ namespace Apollo.RtMidi.Devices {
         public string Name { get; private set; }
         public bool Open() => _rtMidiDevice.Open();
         public void Close() => _rtMidiDevice.Close();
-        
+
+        public void Abandon() {
+            if (_disposed) return;
+
+            try {
+                Disposing();
+                _rtMidiDevice.Abandon();
+
+            } finally {
+                _disposed = true;
+            }
+        }
+
         public void Dispose() {
             if (_disposed) return;
 

--- a/Apollo/RtMidi/Unmanaged/Devices/RtMidiDevice.cs
+++ b/Apollo/RtMidi/Unmanaged/Devices/RtMidiDevice.cs
@@ -114,9 +114,17 @@ namespace Apollo.RtMidi.Unmanaged.Devices {
             if (IsOpen)
                 Close();
 
-            if (Handle != IntPtr.Zero) 
+            if (Handle != IntPtr.Zero)
                 DestroyDevice();
 
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        // Drop a physically-removed device without any native call: on newer Windows,
+        // closing/freeing a vanished WinMM device faults in the driver
+        public void Abandon() {
+            IsOpen = false;
             _disposed = true;
             GC.SuppressFinalize(this);
         }


### PR DESCRIPTION
Disconnecting a Launchpad on newer Windows crashed Apollo because RtMidi's `closePort`/`free` faults inside the WinMM driver when the device is already physically gone - a native crash managed code can't catch.
Since `MIDI.Disconnect` only runs once the ports have already vanished, the fix adds an `Abandon()` path that drops the dead handle (and suppresses its finalizer) instead of calling into native at all.

Logs of the error:
```
[00:00:14.1079373] MIDI Disconnected MIDIIN2 (LPX MIDI)
MidiInWinMM::openPort: error closing Windows MM MIDI input port (midiInUnprepareHeader).
--- crash ----
```

